### PR TITLE
ROUND3

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/BrandCatalogFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/BrandCatalogFacade.java
@@ -1,0 +1,38 @@
+package com.loopers.application.catalog;
+
+import com.loopers.domain.catalog.Brand;
+import com.loopers.domain.catalog.BrandCatalogService;
+import com.loopers.domain.catalog.ProductCatalog;
+import com.loopers.domain.catalog.ProductCatalogService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class BrandCatalogFacade {
+
+    private final BrandCatalogService brandCatalogService;
+    private final ProductCatalogService productCatalogService;
+
+    public BrandCatalogFacade(BrandCatalogService brandCatalogService, ProductCatalogService productCatalogService) {
+        this.brandCatalogService = brandCatalogService;
+        this.productCatalogService = productCatalogService;
+    }
+
+    public BrandDetailInfo getBrandDetailWithProducts(Long brandId){
+        Brand brand = brandCatalogService.find(brandId)
+                .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "해당 ID의 브랜드를 찾을 수 없습니다."));
+
+        List<ProductCatalog> productCatalogs = productCatalogService.findTop5ByBrandIdOrderByPublishedAtDesc(brandId);
+
+        List<ProductCatalogInfo> productCatalogInfos = productCatalogs.stream()
+                .map(productCatalog -> ProductCatalogInfo.from(productCatalog, brand.getBrandName()))
+                .collect(Collectors.toList());
+
+        return BrandDetailInfo.from(brand, productCatalogInfos);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/BrandCatalogFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/BrandCatalogFacade.java
@@ -1,6 +1,6 @@
 package com.loopers.application.catalog;
 
-import com.loopers.domain.catalog.Brand;
+import com.loopers.domain.catalog.BrandCatalog;
 import com.loopers.domain.catalog.BrandCatalogService;
 import com.loopers.domain.catalog.ProductCatalog;
 import com.loopers.domain.catalog.ProductCatalogService;
@@ -23,16 +23,16 @@ public class BrandCatalogFacade {
     }
 
     public BrandDetailInfo getBrandDetailWithProducts(Long brandId){
-        Brand brand = brandCatalogService.find(brandId)
+        BrandCatalog brandCatalog = brandCatalogService.find(brandId)
                 .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "해당 ID의 브랜드를 찾을 수 없습니다."));
 
         List<ProductCatalog> productCatalogs = productCatalogService.findTop5ByBrandIdOrderByPublishedAtDesc(brandId);
 
         List<ProductCatalogInfo> productCatalogInfos = productCatalogs.stream()
-                .map(productCatalog -> ProductCatalogInfo.from(productCatalog, brand.getBrandName()))
+                .map(productCatalog -> ProductCatalogInfo.from(productCatalog, brandCatalog.getBrandName()))
                 .collect(Collectors.toList());
 
-        return BrandDetailInfo.from(brand, productCatalogInfos);
+        return BrandDetailInfo.from(brandCatalog, productCatalogInfos);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/BrandDetailInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/BrandDetailInfo.java
@@ -1,0 +1,18 @@
+package com.loopers.application.catalog;
+
+import com.loopers.domain.catalog.Brand;
+
+import java.util.List;
+
+public record BrandDetailInfo (
+        String brandName,
+        String logoUrl,
+        List<ProductCatalogInfo> products
+){
+    public static BrandDetailInfo from(Brand brand, List<ProductCatalogInfo> products) {
+        return new BrandDetailInfo(
+                brand.getBrandName(), brand.getLogoUrl(), products
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/BrandDetailInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/BrandDetailInfo.java
@@ -1,6 +1,6 @@
 package com.loopers.application.catalog;
 
-import com.loopers.domain.catalog.Brand;
+import com.loopers.domain.catalog.BrandCatalog;
 
 import java.util.List;
 
@@ -9,9 +9,9 @@ public record BrandDetailInfo (
         String logoUrl,
         List<ProductCatalogInfo> products
 ){
-    public static BrandDetailInfo from(Brand brand, List<ProductCatalogInfo> products) {
+    public static BrandDetailInfo from(BrandCatalog brandCatalog, List<ProductCatalogInfo> products) {
         return new BrandDetailInfo(
-                brand.getBrandName(), brand.getLogoUrl(), products
+                brandCatalog.getBrandName(), brandCatalog.getLogoUrl(), products
         );
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCatalogDetailInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCatalogDetailInfo.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.List;
 
-public record ProductDetailInfo(
+public record ProductCatalogDetailInfo(
         Long productId,
         String brandName,
         String productName,
@@ -12,7 +12,7 @@ public record ProductDetailInfo(
         String imageUrl,
         String description,
         ZonedDateTime publishedAt,
-        List<ProductDetailInfo.SkuInfo> skuInfos
+        List<ProductCatalogDetailInfo.SkuInfo> skuInfos
 ){
 
 
@@ -21,7 +21,7 @@ public record ProductDetailInfo(
         BigDecimal unitPrice,
         String imageUrl,
         String status,
-        List<ProductDetailInfo.OptionDetail> optionDetails
+        List<ProductCatalogDetailInfo.OptionDetail> optionDetails
     ){
     }
     public record OptionDetail(

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCatalogFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCatalogFacade.java
@@ -1,19 +1,20 @@
 package com.loopers.application.catalog;
 
-import com.loopers.domain.catalog.Brand;
+import com.loopers.application.like.LikeProductDetailInfo;
+import com.loopers.domain.catalog.BrandCatalog;
 import com.loopers.domain.catalog.BrandCatalogService;
 import com.loopers.domain.catalog.ProductCatalog;
 import com.loopers.domain.catalog.ProductCatalogService;
+import com.loopers.domain.like.Like;
+import com.loopers.domain.like.LikeService;
 import com.loopers.domain.product.ProductSku;
 import com.loopers.domain.product.ProductSkuService;
 import com.loopers.domain.product.SkuOption;
 import com.loopers.interfaces.api.catalog.ProductCatalogV1Dto;
+import com.loopers.interfaces.api.like.LikeV1Dto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -27,61 +28,28 @@ public class ProductCatalogFacade {
     private final BrandCatalogService brandCatalogService;
     private final ProductCatalogService productCatalogService;
     private final ProductSkuService productSkuService;
+    private final LikeService likeService;
 
-    public ProductCatalogFacade(BrandCatalogService brandCatalogService, ProductCatalogService productCatalogService, ProductSkuService productSkuService) {
+    public ProductCatalogFacade(BrandCatalogService brandCatalogService, ProductCatalogService productCatalogService, ProductSkuService productSkuService, LikeService likeService) {
         this.brandCatalogService = brandCatalogService;
         this.productCatalogService = productCatalogService;
         this.productSkuService = productSkuService;
+        this.likeService = likeService;
     }
 
-    public ProductDetailInfo retrieveProductDetail(Long productId){
-// 1. ProductCatalog 정보 조회
-        // findById 결과를 Optional로 받고, 없으면 NOT_FOUND 예외 발생
+    public ProductCatalogDetailInfo retrieveProductDetail(Long productId){
         ProductCatalog productCatalog = productCatalogService.findById(productId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));
 
-        // 2. Brand 정보 조회 (ProductCatalog의 brandId 사용)
-        Brand brand = brandCatalogService.find(productCatalog.getBrandId()) // find(id)는 Optional<Brand> 반환 가정
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "브랜드를 찾을 수 없습니다.")); // 이 경우는 매우 드물어야 함 (데이터 무결성)
+        BrandCatalog brandCatalog = brandCatalogService.find(productCatalog.getBrandId())
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "브랜드를 찾을 수 없습니다."));
 
-        // 3. 해당 ProductCatalog에 속한 모든 ProductSku 조회
         List<ProductSku> skus = productSkuService.findByProductCatalogId(productId);
+        List<ProductCatalogDetailInfo.SkuInfo> skuInfos = convertSkuToSkuInfos(skus);
 
-        // 4. 각 ProductSku에 대한 Option 정보 조회 및 조합
-        // SKU가 많을 경우 N+1 쿼리를 피하기 위해 SkuOption, OptionName, OptionValue를 JOIN FETCH로 한 번에 가져오는 쿼리가 ProductSkuService 내부에 필요
-        // 또는, 조회된 모든 SkuOption에서 필요한 OptionName/Value ID를 추출하여 한 번에 OptionName, OptionValue를 조회 후 Map으로 변환
-
-        // 4-1. 모든 SKU 옵션들을 조회 (SKU-OptionName-OptionValue 조인을 통해)
-        // ProductSkuService에 이런 메서드가 있다고 가정:
-        // List<ProductSkuWithOptionInfo> skusWithOptions = productSkuService.findSkusWithOptionsByProductCatalogId(productCatalogId);
-
-        // 또는 수동으로 매핑:
-        List<ProductDetailInfo.SkuInfo> skuInfos = skus.stream().map(sku -> {
-            // 각 SKU에 연결된 SkuOption들을 조회 (N+1 문제 가능성 있으므로, SkuOption fetch join 고려)
-            List<SkuOption> skuOptions = sku.getSkuOptions(); // SkuOption 엔티티에 @OneToMany(mappedBy="productSku", fetch = FetchType.EAGER) 또는 별도 서비스 호출
-
-            // SkuOption에서 OptionName과 OptionValue 정보 추출
-            List<ProductDetailInfo.OptionDetail> optionDetails = skuOptions.stream()
-                    .map(so -> new ProductDetailInfo.OptionDetail(
-                            so.getOptionName().getName(),
-                            so.getOptionValue().getValue()
-                    ))
-                    .collect(Collectors.toList());
-
-            return new ProductDetailInfo.SkuInfo(
-                    sku.getId(),
-                    sku.getUnitPrice(),
-                    sku.getImageUrl(),
-                    sku.getStatus().getCode(), // SkuStatus의 description 사용
-                    optionDetails
-            );
-        }).collect(Collectors.toList());
-
-
-        // 5. 모든 정보를 조합하여 ProductDetailInfo DTO 생성 및 반환
-        return new ProductDetailInfo(
+        return new ProductCatalogDetailInfo(
                 productCatalog.getId(),
-                brand.getBrandName(), // Brand 이름 사용
+                brandCatalog.getBrandName(),
                 productCatalog.getProductName(),
                 productCatalog.getBasePrice(),
                 productCatalog.getImageUrl(),
@@ -90,6 +58,36 @@ public class ProductCatalogFacade {
                 skuInfos
         );
     }
+
+    public Page<LikeProductDetailInfo> getLikedProductDetails(Long userId, LikeV1Dto.LikeRequest request){
+        Sort sort = Sort.by(Sort.Direction.fromString(request.direction().name()), request.sortBy().getPropertyName());
+        Pageable pageable = PageRequest.of(request.page(), request.size(), sort);
+
+        Page<Like> likesPage = likeService.findByIdUserId(userId, pageable);
+
+        List<Long> productCatalogIds = likesPage.getContent().stream()
+                .map(like -> like.getId().getProductCatalogId())
+                .collect(Collectors.toList());
+
+        List<ProductCatalog> productCatalogs = productCatalogService.findByIds(productCatalogIds);
+
+        Map<Long, ProductCatalog> productCatalogMap = productCatalogs.stream()
+                .collect(Collectors.toMap(ProductCatalog::getId, productCatalog -> productCatalog));
+
+        List<LikeProductDetailInfo> likedProductDetails = likesPage.getContent().stream()
+                .map(like -> {
+                    ProductCatalog productCatalog = productCatalogMap.get(like.getId().getProductCatalogId());
+                    return new LikeProductDetailInfo(like, productCatalog);
+                })
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(
+                likedProductDetails,
+                pageable,
+                likesPage.getTotalElements()
+        );
+    }
+
 
     public Page<ProductCatalogInfo> retrieveProductCatalog(Optional<Long> brandId, ProductCatalogV1Dto.ProductCatalogRequest request){
         Sort sort = Sort.by(Sort.Direction.fromString(request.direction().name()), request.sortBy().getPropertyName());
@@ -103,37 +101,44 @@ public class ProductCatalogFacade {
 
     private Page<ProductCatalogInfo> convertToProductCatalogInfoPage(Page<ProductCatalog> productCatalogsPage) {
         List<ProductCatalog> productCatalogs = productCatalogsPage.getContent();
-        // 1. ProductCatalog 리스트에서 모든 고유한 brandId를 추출
+
         Set<Long> brandIds = productCatalogs.stream()
-                .map(ProductCatalog::getBrandId) // ProductCatalog에 getBrandId()가 있다고 가정
-                .collect(Collectors.toSet()); // 중복 제거를 위해 Set 사용
+                .map(ProductCatalog::getBrandId)
+                .collect(Collectors.toSet());
 
-        // 2. 추출된 brandId들을 사용하여 모든 Brand 정보를 한 번에 조회 (단일 쿼리)
-        List<Brand> brands = brandCatalogService.findAllById(brandIds);
+        List<BrandCatalog> brandCatalogs = brandCatalogService.findAllByIds(brandIds);
 
-        // 3. Brand 리스트를 brandId를 키로, brandName을 값으로 하는 Map으로 변환
-        //    (조회 속도를 높이기 위함)
-        Map<Long, String> brandIdToNameMap = brands.stream()
-                .collect(Collectors.toMap(Brand::getId, Brand::getBrandName));
+        Map<Long, String> brandIdToNameMap = brandCatalogs.stream()
+                .collect(Collectors.toMap(BrandCatalog::getId, BrandCatalog::getBrandName));
 
-        // 4. ProductCatalog 리스트를 순회하며 ProductCatalogInfo DTO로 변환
-        //    이때 brandIdToNameMap을 사용하여 각 ProductCatalog의 brandName을 찾습니다.
         return productCatalogsPage.map(productCatalog -> {
             String brandName = brandIdToNameMap.getOrDefault(
-                    productCatalog.getBrandId(), "Unknown Brand"); // Brand 없으면 기본값
+                    productCatalog.getBrandId(), "Unknown Brand");
 
             return ProductCatalogInfo.from(productCatalog, brandName);
         });
-
-//            productCatalogs.stream()
-//                    .map(productCatalog -> {
-//                        // Map에서 brandId에 해당하는 brandName을 찾고, 없으면 "Unknown Brand" 등으로 처리
-//                        String brandName = brandIdToNameMap.getOrDefault(
-//                                productCatalog.getBrandId(), "Unknown Brand");
-//
-//                        return ProductCatalogInfo.from(productCatalog, brandName);
-//                    })
-//                    .collect(Collectors.toList());
-//        }
     }
+
+    private List<ProductCatalogDetailInfo.SkuInfo> convertSkuToSkuInfos(List<ProductSku> skus) {
+        List<ProductCatalogDetailInfo.SkuInfo> skuInfos = skus.stream().map(sku -> {
+            List<SkuOption> skuOptions = sku.getSkuOptions();
+
+            List<ProductCatalogDetailInfo.OptionDetail> optionDetails = skuOptions.stream()
+                    .map(so -> new ProductCatalogDetailInfo.OptionDetail(
+                            so.getOptionName().getName(),
+                            so.getOptionValue().getValue()
+                    ))
+                    .collect(Collectors.toList());
+
+            return new ProductCatalogDetailInfo.SkuInfo(
+                    sku.getId(),
+                    sku.getUnitPrice(),
+                    sku.getImageUrl(),
+                    sku.getStatus().getCode(),
+                    optionDetails
+            );
+        }).collect(Collectors.toList());
+        return skuInfos;
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCatalogFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCatalogFacade.java
@@ -1,0 +1,139 @@
+package com.loopers.application.catalog;
+
+import com.loopers.domain.catalog.Brand;
+import com.loopers.domain.catalog.BrandCatalogService;
+import com.loopers.domain.catalog.ProductCatalog;
+import com.loopers.domain.catalog.ProductCatalogService;
+import com.loopers.domain.product.ProductSku;
+import com.loopers.domain.product.ProductSkuService;
+import com.loopers.domain.product.SkuOption;
+import com.loopers.interfaces.api.catalog.ProductCatalogV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class ProductCatalogFacade {
+    private final BrandCatalogService brandCatalogService;
+    private final ProductCatalogService productCatalogService;
+    private final ProductSkuService productSkuService;
+
+    public ProductCatalogFacade(BrandCatalogService brandCatalogService, ProductCatalogService productCatalogService, ProductSkuService productSkuService) {
+        this.brandCatalogService = brandCatalogService;
+        this.productCatalogService = productCatalogService;
+        this.productSkuService = productSkuService;
+    }
+
+    public ProductDetailInfo retrieveProductDetail(Long productId){
+// 1. ProductCatalog 정보 조회
+        // findById 결과를 Optional로 받고, 없으면 NOT_FOUND 예외 발생
+        ProductCatalog productCatalog = productCatalogService.findById(productId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));
+
+        // 2. Brand 정보 조회 (ProductCatalog의 brandId 사용)
+        Brand brand = brandCatalogService.find(productCatalog.getBrandId()) // find(id)는 Optional<Brand> 반환 가정
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "브랜드를 찾을 수 없습니다.")); // 이 경우는 매우 드물어야 함 (데이터 무결성)
+
+        // 3. 해당 ProductCatalog에 속한 모든 ProductSku 조회
+        List<ProductSku> skus = productSkuService.findByProductCatalogId(productId);
+
+        // 4. 각 ProductSku에 대한 Option 정보 조회 및 조합
+        // SKU가 많을 경우 N+1 쿼리를 피하기 위해 SkuOption, OptionName, OptionValue를 JOIN FETCH로 한 번에 가져오는 쿼리가 ProductSkuService 내부에 필요
+        // 또는, 조회된 모든 SkuOption에서 필요한 OptionName/Value ID를 추출하여 한 번에 OptionName, OptionValue를 조회 후 Map으로 변환
+
+        // 4-1. 모든 SKU 옵션들을 조회 (SKU-OptionName-OptionValue 조인을 통해)
+        // ProductSkuService에 이런 메서드가 있다고 가정:
+        // List<ProductSkuWithOptionInfo> skusWithOptions = productSkuService.findSkusWithOptionsByProductCatalogId(productCatalogId);
+
+        // 또는 수동으로 매핑:
+        List<ProductDetailInfo.SkuInfo> skuInfos = skus.stream().map(sku -> {
+            // 각 SKU에 연결된 SkuOption들을 조회 (N+1 문제 가능성 있으므로, SkuOption fetch join 고려)
+            List<SkuOption> skuOptions = sku.getSkuOptions(); // SkuOption 엔티티에 @OneToMany(mappedBy="productSku", fetch = FetchType.EAGER) 또는 별도 서비스 호출
+
+            // SkuOption에서 OptionName과 OptionValue 정보 추출
+            List<ProductDetailInfo.OptionDetail> optionDetails = skuOptions.stream()
+                    .map(so -> new ProductDetailInfo.OptionDetail(
+                            so.getOptionName().getName(),
+                            so.getOptionValue().getValue()
+                    ))
+                    .collect(Collectors.toList());
+
+            return new ProductDetailInfo.SkuInfo(
+                    sku.getId(),
+                    sku.getUnitPrice(),
+                    sku.getImageUrl(),
+                    sku.getStatus().getCode(), // SkuStatus의 description 사용
+                    optionDetails
+            );
+        }).collect(Collectors.toList());
+
+
+        // 5. 모든 정보를 조합하여 ProductDetailInfo DTO 생성 및 반환
+        return new ProductDetailInfo(
+                productCatalog.getId(),
+                brand.getBrandName(), // Brand 이름 사용
+                productCatalog.getProductName(),
+                productCatalog.getBasePrice(),
+                productCatalog.getImageUrl(),
+                productCatalog.getDescription(),
+                productCatalog.getPublishedAt(),
+                skuInfos
+        );
+    }
+
+    public Page<ProductCatalogInfo> retrieveProductCatalog(Optional<Long> brandId, ProductCatalogV1Dto.ProductCatalogRequest request){
+        Sort sort = Sort.by(Sort.Direction.fromString(request.direction().name()), request.sortBy().getPropertyName());
+        Pageable pageable = PageRequest.of(request.page(), request.size(), sort);
+
+        brandId.ifPresent(id -> brandCatalogService.find(id)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "Brand 를 찾을 수 없습니다.")));
+        Page<ProductCatalog> productCatalogs = productCatalogService.find(brandId, pageable);
+        return convertToProductCatalogInfoPage(productCatalogs);
+    }
+
+    private Page<ProductCatalogInfo> convertToProductCatalogInfoPage(Page<ProductCatalog> productCatalogsPage) {
+        List<ProductCatalog> productCatalogs = productCatalogsPage.getContent();
+        // 1. ProductCatalog 리스트에서 모든 고유한 brandId를 추출
+        Set<Long> brandIds = productCatalogs.stream()
+                .map(ProductCatalog::getBrandId) // ProductCatalog에 getBrandId()가 있다고 가정
+                .collect(Collectors.toSet()); // 중복 제거를 위해 Set 사용
+
+        // 2. 추출된 brandId들을 사용하여 모든 Brand 정보를 한 번에 조회 (단일 쿼리)
+        List<Brand> brands = brandCatalogService.findAllById(brandIds);
+
+        // 3. Brand 리스트를 brandId를 키로, brandName을 값으로 하는 Map으로 변환
+        //    (조회 속도를 높이기 위함)
+        Map<Long, String> brandIdToNameMap = brands.stream()
+                .collect(Collectors.toMap(Brand::getId, Brand::getBrandName));
+
+        // 4. ProductCatalog 리스트를 순회하며 ProductCatalogInfo DTO로 변환
+        //    이때 brandIdToNameMap을 사용하여 각 ProductCatalog의 brandName을 찾습니다.
+        return productCatalogsPage.map(productCatalog -> {
+            String brandName = brandIdToNameMap.getOrDefault(
+                    productCatalog.getBrandId(), "Unknown Brand"); // Brand 없으면 기본값
+
+            return ProductCatalogInfo.from(productCatalog, brandName);
+        });
+
+//            productCatalogs.stream()
+//                    .map(productCatalog -> {
+//                        // Map에서 brandId에 해당하는 brandName을 찾고, 없으면 "Unknown Brand" 등으로 처리
+//                        String brandName = brandIdToNameMap.getOrDefault(
+//                                productCatalog.getBrandId(), "Unknown Brand");
+//
+//                        return ProductCatalogInfo.from(productCatalog, brandName);
+//                    })
+//                    .collect(Collectors.toList());
+//        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCatalogInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCatalogInfo.java
@@ -1,0 +1,39 @@
+package com.loopers.application.catalog;
+
+import com.loopers.domain.catalog.ProductCatalog;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public record ProductCatalogInfo (
+        String brandName,
+        String productName,
+        BigDecimal basePrice,
+        String imageUrl,
+        String description
+){
+    public static ProductCatalogInfo from(ProductCatalog product, String brandName){
+        return new ProductCatalogInfo(
+                brandName,
+                product.getProductName(),
+                product.getBasePrice(),
+                product.getImageUrl(),
+                product.getDescription()
+        );
+    }
+
+    public static List<ProductCatalogInfo> from(List<ProductCatalog> productCatalogs, Map<Long, String> brandIdToNameMap) {
+        if (productCatalogs == null) {
+            return List.of();
+        }
+        return productCatalogs.stream()
+                .map(product -> {
+                    // ProductCatalog의 brandId를 이용하여 brandName을 Map에서 찾음
+                    String brandName = brandIdToNameMap.getOrDefault(product.getBrandId(), "Unknown Brand"); // getBrandId() 가정
+                    return ProductCatalogInfo.from(product, brandName); // 단일 브랜드 이름을 리스트로
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCatalogInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCatalogInfo.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public record ProductCatalogInfo (
+        Long productCatalogId,
         String brandName,
         String productName,
         BigDecimal basePrice,
@@ -16,6 +17,7 @@ public record ProductCatalogInfo (
 ){
     public static ProductCatalogInfo from(ProductCatalog product, String brandName){
         return new ProductCatalogInfo(
+                product.getId(),
                 brandName,
                 product.getProductName(),
                 product.getBasePrice(),
@@ -30,9 +32,8 @@ public record ProductCatalogInfo (
         }
         return productCatalogs.stream()
                 .map(product -> {
-                    // ProductCatalog의 brandId를 이용하여 brandName을 Map에서 찾음
-                    String brandName = brandIdToNameMap.getOrDefault(product.getBrandId(), "Unknown Brand"); // getBrandId() 가정
-                    return ProductCatalogInfo.from(product, brandName); // 단일 브랜드 이름을 리스트로
+                    String brandName = brandIdToNameMap.getOrDefault(product.getBrandId(), "Unknown Brand");
+                    return ProductCatalogInfo.from(product, brandName);
                 })
                 .collect(Collectors.toList());
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductDetailInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductDetailInfo.java
@@ -1,0 +1,32 @@
+package com.loopers.application.catalog;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public record ProductDetailInfo(
+        Long productId,
+        String brandName,
+        String productName,
+        BigDecimal basePrice,
+        String imageUrl,
+        String description,
+        ZonedDateTime publishedAt,
+        List<ProductDetailInfo.SkuInfo> skuInfos
+){
+
+
+    public record SkuInfo(
+        Long skuId,
+        BigDecimal unitPrice,
+        String imageUrl,
+        String status,
+        List<ProductDetailInfo.OptionDetail> optionDetails
+    ){
+    }
+    public record OptionDetail(
+        String optionName,
+        String optionValue
+    ){
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -1,0 +1,41 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.like.LikeService;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LikeFacade {
+    private final LikeService likeService;
+
+    public LikeFacade(LikeService likeService) {
+        this.likeService = likeService;
+    }
+
+    @Transactional
+    public void like(Long userId, Long productCataglogId){
+        likeService.find(userId, productCataglogId)
+                .ifPresentOrElse(
+                        like -> {
+                            if(like.getDeletedAt() != null){
+                                like.restore();
+                            }
+                        },
+                        () -> {
+                            likeService.save(userId, productCataglogId);
+                        }
+                );
+    }
+
+    @Transactional
+    public void unlike(Long userId, Long productCataglogId){
+        likeService.find(userId, productCataglogId)
+                .ifPresent(
+                        like -> {
+                            if(like.getDeletedAt() == null){
+                                like.delete();
+                            }
+                        }
+                );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeProductDetailInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeProductDetailInfo.java
@@ -1,0 +1,35 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.catalog.ProductCatalog;
+import com.loopers.domain.like.Like;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+public class LikeProductDetailInfo {
+    private Long likeId;
+    private Long userId;
+    private Long productCatalogId;
+    private ZonedDateTime likedAt;
+
+    private String productName;
+    private BigDecimal basePrice;
+    private String imageUrl;
+    private String description;
+    private Long brandId;
+
+    public LikeProductDetailInfo(Like productLike, ProductCatalog productCatalog) {
+        this.likeId = productLike.getId().getProductCatalogId();
+        this.userId = productLike.getId().getUserId();
+        this.productCatalogId = productLike.getId().getProductCatalogId();
+        this.likedAt = productLike.getCreatedAt();
+
+        if (productCatalog != null) {
+            this.productName = productCatalog.getProductName();
+            this.basePrice = productCatalog.getBasePrice();
+            this.imageUrl = productCatalog.getImageUrl();
+            this.description = productCatalog.getDescription();
+            this.brandId = productCatalog.getBrandId();
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCreateCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCreateCommand.java
@@ -1,0 +1,19 @@
+package com.loopers.application.order;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record OrderCreateCommand(
+        String userId,
+        List<OrderItemCreateCommand> items
+){
+    public record OrderItemCreateCommand(
+            Long productSkuId,
+            Long productCatalogId,
+            Long quantity,
+            BigDecimal unitPrice,
+            String productName
+    ){
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,0 +1,117 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.catalog.ProductCatalog;
+import com.loopers.domain.catalog.ProductCatalogService;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.point.DeductPointCommand;
+import com.loopers.domain.point.PointService;
+import com.loopers.domain.product.ProductSku;
+import com.loopers.domain.product.ProductSkuService;
+import com.loopers.domain.stock.StockService;
+import com.loopers.interfaces.api.order.OrderV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+public class OrderFacade {
+    private final OrderService orderService;
+    private final ProductCatalogService productCatalogService;
+    private final ProductSkuService productSkuService;
+
+    private final PointService pointService;
+    private final StockService stockService;
+
+    public OrderFacade(OrderService orderService, ProductCatalogService productCatalogService, ProductSkuService productSkuService, PointService pointService, StockService stockService) {
+        this.orderService = orderService;
+        this.productCatalogService = productCatalogService;
+        this.productSkuService = productSkuService;
+        this.pointService = pointService;
+        this.stockService = stockService;
+    }
+
+    @Transactional
+    public OrderInfo.OrderDetailInfo createOrder(String userId, OrderV1Dto.OrderCreateRequest request) {
+        if (request.items() == null || request.items().isEmpty()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "주문할 상품 항목이 없습니다.");
+        }
+
+        Set<Long> requestedSkuIds = request.items().stream()
+                .map(command -> command.productSkuId())
+                .collect(Collectors.toSet());
+
+        List<ProductSku> foundSkus = productSkuService.findByIds(requestedSkuIds);
+        Map<Long, ProductSku> skuMap = foundSkus.stream()
+                .collect(Collectors.toMap(ProductSku::getId, Function.identity()));
+
+        Set<Long> catalogIds = foundSkus.stream()
+                .map(ProductSku::getProductCatalogId)
+                .collect(Collectors.toSet());
+
+        List<ProductCatalog> foundCatalogs = productCatalogService.findByIds(catalogIds);
+        Map<Long, ProductCatalog> catalogMap = foundCatalogs.stream()
+                .collect(Collectors.toMap(ProductCatalog::getId, Function.identity()));
+
+        List<OrderCreateCommand.OrderItemCreateCommand> orderItemsToCreate = request.items().stream()
+                .map(reqItem -> {
+                    ProductSku productSku = skuMap.get(reqItem.productSkuId());
+                    if (productSku == null) {
+                        throw new CoreException(ErrorType.BAD_REQUEST, "Product SKU를 찾을 수 없습니다: " + reqItem.productSkuId());
+                    }
+
+                    if (productSku.getStatus() != ProductSku.SkuStatus.AVAILABLE){
+                        throw new CoreException(ErrorType.CONFLICT, "상품이 판매 중 상태가 아닙니다. " + reqItem.productSkuId());
+                    }
+
+                    ProductCatalog productCatalog = catalogMap.get(productSku.getProductCatalogId());
+                    if (productCatalog == null) {
+                        throw new CoreException(ErrorType.BAD_REQUEST,"Product Catalog를 찾을 수 없습니다: " + productSku.getProductCatalogId());
+                    }
+
+                    // 재고 차감
+                    stockService.decreaseStock(reqItem.productSkuId(), reqItem.quantity());
+
+                    return new OrderCreateCommand.OrderItemCreateCommand(
+                            reqItem.productSkuId(),
+                            productSku.getProductCatalogId(),
+                            reqItem.quantity(),
+                            productSku.getUnitPrice(),
+                            productCatalog.getProductName()
+                    );
+                })
+                .collect(Collectors.toList());
+
+        OrderCreateCommand orderCreateRequest = new OrderCreateCommand(
+                userId,
+                orderItemsToCreate
+        );
+
+        Order savedOrder = orderService.createOrder(orderCreateRequest);
+        // 포인트 차감
+        pointService.deduct(DeductPointCommand.of(savedOrder.getUserId(), savedOrder.getTotalOrderPrice()));
+        savedOrder.updateStatus("COMPLETED");
+        return OrderInfo.OrderDetailInfo.from(savedOrder);
+    }
+
+    public Page<OrderInfo.OrderResponseInfo> getOrderList(Long userId, OrderV1Dto.OrderSelectRequest request) {
+        Sort sort = Sort.by(Sort.Direction.fromString(request.direction().name()), request.sortBy());
+        Pageable pageable = PageRequest.of(request.page(), request.size(), sort);
+        return orderService.getOrderList(userId, pageable);
+    }
+
+    public OrderInfo.OrderDetailInfo getOrderDetail(Long orderId) {
+        return orderService.getOrderDetail(orderId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderInfo.java
@@ -1,0 +1,74 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderItem;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OrderInfo {
+    public record OrderResponseInfo(
+            Long orderId,
+            String userId,
+            BigDecimal totalOrderPrice,
+            String status,
+            ZonedDateTime orderedAt
+    ){
+
+        public static OrderResponseInfo from(Order order){
+            return new OrderResponseInfo(
+                    order.getId(),
+                    order.getUserId(),
+                    order.getTotalOrderPrice(),
+                    order.getStatus(),
+                    order.getCreatedAt()
+            );
+        }
+    }
+
+    public record OrderDetailInfo(
+            Long orderId,
+            String userId,
+            BigDecimal totalOrderPrice,
+            String status,
+            ZonedDateTime orderedAt,
+            List<OrderItemInfo> items
+    ){
+        public static OrderDetailInfo from(Order order){
+            return new OrderDetailInfo(
+                    order.getId(),
+                    order.getUserId(),
+                    order.getTotalOrderPrice(),
+                    order.getStatus(),
+                    order.getCreatedAt(),
+                    order.getOrderItems().stream()
+                            .map(OrderItemInfo::from)
+                            .collect(Collectors.toList())
+            );
+        }
+    }
+
+    public record OrderItemInfo(
+            Long orderItemId,
+            Long productSkuId,
+            Long productCatalogId,
+            Long quantity,
+            BigDecimal totalItemPrice,
+            String productName,
+            BigDecimal unitPrice
+    ){
+        public static OrderItemInfo from(OrderItem item) {
+            return new OrderItemInfo(
+                    item.getId(),
+                    item.getProductSkuId(),
+                    item.getProductCatalogId(),
+                    item.getQuantity(),
+                    item.getTotalItemPrice(),
+                    item.getOrderItemProductName(),
+                    item.getOrderItemUnitPrice()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -2,20 +2,27 @@ package com.loopers.application.point;
 
 import com.loopers.domain.point.ChargePointCommand;
 import com.loopers.domain.point.PointService;
+import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.api.point.PointV1Dto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
+
 @Component
 public class PointFacade {
     private final PointService pointService;
+    private final UserService userService;
 
-    public PointFacade(PointService pointService) {
+    public PointFacade(PointService pointService, UserService userService) {
         this.pointService = pointService;
+        this.userService = userService;
     }
 
-    public long charge(String userId, PointV1Dto.ChargePointRequest chargePointRequest) {
+    public BigDecimal charge(String userId, PointV1Dto.ChargePointRequest chargePointRequest) {
+        userService.find(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 User 입니다."));
         ChargePointCommand chargeCommand = ChargePointCommand.of(userId, chargePointRequest.point());
         return pointService.charge(chargeCommand);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
@@ -1,12 +1,14 @@
 package com.loopers.application.point;
 
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.point.Point;
+
+import java.math.BigDecimal;
 
 public record PointInfo (
         String userId,
-        long point
+        BigDecimal point
 ){
-    public static PointInfo from(UserEntity user){
-        return new PointInfo(user.getUserId(), user.getPoint());
+    public static PointInfo from(Point point){
+        return new PointInfo(point.getUserId(), point.getPoint());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
@@ -1,15 +1,15 @@
 package com.loopers.application.user;
 
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.User;
 
 public record UserInfo (
     String userId,
     String userName,
-    UserEntity.Gender gender,
+    User.Gender gender,
     String birth,
     String email
 ){
-    public static UserInfo from(UserEntity entity) {
+    public static UserInfo from(User entity) {
         return new UserInfo(
                 entity.getUserId(),
                 entity.getUserName(),

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/Brand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/Brand.java
@@ -4,11 +4,14 @@ package com.loopers.domain.catalog;
 import com.loopers.domain.BaseEntity;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import io.micrometer.common.util.StringUtils;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -17,6 +20,8 @@ import java.net.URL;
 @Entity
 @Table(name = "brand")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@Getter
 public class Brand extends BaseEntity {
     @Column(name = "brand_name", nullable = false, length = 100, unique = true)
     String brandName;
@@ -36,7 +41,7 @@ public class Brand extends BaseEntity {
     }
 
     private void validate(String brandName, String logoUrl) {
-        if (brandName == null || brandName.length() > 100)
+        if (StringUtils.isBlank(brandName) || brandName.length() > 100)
             throw new CoreException(ErrorType.BAD_REQUEST, "브랜드 이름은 100자 이내여야 합니다.");
 
         if (logoUrl == null) return;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/Brand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/Brand.java
@@ -1,0 +1,49 @@
+package com.loopers.domain.catalog;
+
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+@Entity
+@Table(name = "brand")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Brand extends BaseEntity {
+    @Column(name = "brand_name", nullable = false, length = 100, unique = true)
+    String brandName;
+
+    @Column(name = "logo_url", length = 2048)
+    String logoUrl;
+
+    private Brand(String brandName, String logoUrl) {
+        validate(brandName, logoUrl);
+
+        this.brandName = brandName;
+        this.logoUrl = logoUrl;
+    }
+
+    public static Brand from(String brandName, String logoUrl) {
+        return new Brand(brandName, logoUrl);
+    }
+
+    private void validate(String brandName, String logoUrl) {
+        if (brandName == null || brandName.length() > 100)
+            throw new CoreException(ErrorType.BAD_REQUEST, "브랜드 이름은 100자 이내여야 합니다.");
+
+        if (logoUrl == null) return;
+        try{
+            new URL(logoUrl).toURI();
+        } catch (MalformedURLException | URISyntaxException e){
+            throw new CoreException(ErrorType.BAD_REQUEST, "올바른 URL 형식이 아닙니다.");
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/BrandCatalog.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/BrandCatalog.java
@@ -22,22 +22,22 @@ import java.net.URL;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString
 @Getter
-public class Brand extends BaseEntity {
+public class BrandCatalog extends BaseEntity {
     @Column(name = "brand_name", nullable = false, length = 100, unique = true)
     String brandName;
 
     @Column(name = "logo_url", length = 2048)
     String logoUrl;
 
-    private Brand(String brandName, String logoUrl) {
+    private BrandCatalog(String brandName, String logoUrl) {
         validate(brandName, logoUrl);
 
         this.brandName = brandName;
         this.logoUrl = logoUrl;
     }
 
-    public static Brand from(String brandName, String logoUrl) {
-        return new Brand(brandName, logoUrl);
+    public static BrandCatalog from(String brandName, String logoUrl) {
+        return new BrandCatalog(brandName, logoUrl);
     }
 
     private void validate(String brandName, String logoUrl) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/BrandCatalogService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/BrandCatalogService.java
@@ -1,0 +1,24 @@
+package com.loopers.domain.catalog;
+
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class BrandCatalogService {
+    private final BrandRepository brandRepository;
+
+    public BrandCatalogService(BrandRepository brandRepository) {
+        this.brandRepository = brandRepository;
+    }
+
+    public Optional<Brand> find(Long id) {
+        return brandRepository.find(id);
+    }
+
+    public List<Brand>  findAllById(Iterable<Long> ids){
+        return brandRepository.findAllById(ids);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/BrandCatalogService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/BrandCatalogService.java
@@ -14,11 +14,11 @@ public class BrandCatalogService {
         this.brandRepository = brandRepository;
     }
 
-    public Optional<Brand> find(Long id) {
+    public Optional<BrandCatalog> find(Long id) {
         return brandRepository.find(id);
     }
 
-    public List<Brand>  findAllById(Iterable<Long> ids){
+    public List<BrandCatalog>  findAllByIds(Iterable<Long> ids){
         return brandRepository.findAllById(ids);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/BrandRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/BrandRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.catalog;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BrandRepository {
+    Optional<Brand> find(Long id);
+    Brand save(Brand user);
+    List<Brand> findAllById(Iterable<Long> ids);
+    long count();
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/BrandRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/BrandRepository.java
@@ -4,8 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface BrandRepository {
-    Optional<Brand> find(Long id);
-    Brand save(Brand user);
-    List<Brand> findAllById(Iterable<Long> ids);
+    Optional<BrandCatalog> find(Long id);
+    BrandCatalog save(BrandCatalog user);
+    List<BrandCatalog> findAllById(Iterable<Long> ids);
     long count();
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/ProductCatalog.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/ProductCatalog.java
@@ -3,21 +3,27 @@ package com.loopers.domain.catalog;
 import com.loopers.domain.BaseEntity;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import io.micrometer.common.util.StringUtils;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.ZonedDateTime;
 
 @Entity
-@Table(name = "product_definition")
+@Table(name = "product_catalog")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProductDefinition extends BaseEntity {
+@Getter
+@ToString
+public class ProductCatalog extends BaseEntity {
 
     @Column(name = "ref_brand_id", nullable = false)
     private Long brandId;
@@ -35,7 +41,11 @@ public class ProductDefinition extends BaseEntity {
     @Column(name = "description")
     private String description;
 
-    private ProductDefinition(Long brandId, String productName, BigDecimal basePrice, String imageUrl, String description) {
+    @Column(name = "published_at", updatable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private ZonedDateTime publishedAt;
+
+    private ProductCatalog(Long brandId, String productName, BigDecimal basePrice, String imageUrl, String description) {
         validate(brandId, productName, basePrice, imageUrl);
 
         this.brandId = brandId;
@@ -45,8 +55,8 @@ public class ProductDefinition extends BaseEntity {
         this.description = description;
     }
 
-    public static ProductDefinition from (Long brandId, String productName, BigDecimal basePrice, String imageUrl, String description){
-        return new ProductDefinition(
+    public static ProductCatalog from (Long brandId, String productName, BigDecimal basePrice, String imageUrl, String description){
+        return new ProductCatalog(
                 brandId, productName, basePrice, imageUrl, description
         );
     }
@@ -55,7 +65,7 @@ public class ProductDefinition extends BaseEntity {
         if (brandId == null)
             throw new CoreException(ErrorType.BAD_REQUEST, "Brand 정보가 존재하지 않습니다.");
 
-        if (productName == null || productName.length() > 100)
+        if (StringUtils.isBlank(productName) || productName.length() > 250)
             throw new CoreException(ErrorType.BAD_REQUEST, "상품 이름은 250자 이내여야 합니다.");
 
         if (basePrice == null || basePrice.compareTo(BigDecimal.ZERO) <= 0)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/ProductCatalogService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/ProductCatalogService.java
@@ -1,0 +1,36 @@
+package com.loopers.domain.catalog;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ProductCatalogService {
+    private final ProductRepository productRepository;
+
+    public ProductCatalogService(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    public List<ProductCatalog> findTop5ByBrandIdOrderByPublishedAtDesc(Long id) {
+        return productRepository.findTop5ByBrandIdOrderByPublishedAtDesc(id);
+    }
+
+    public ProductCatalog save(ProductCatalog productCatalog) {
+        return productRepository.save(productCatalog);
+    }
+
+    public Page<ProductCatalog> find(Optional<Long> brandId, Pageable pageable) {
+        if (brandId.isPresent())
+            return productRepository.findByBrandId(brandId.get(), pageable);
+        else
+            return productRepository.findAll(pageable);
+    }
+
+    public Optional<ProductCatalog> findById(Long productId) {
+        return productRepository.find(productId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/ProductCatalogService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/ProductCatalogService.java
@@ -1,9 +1,11 @@
 package com.loopers.domain.catalog;
 
+import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,6 +21,7 @@ public class ProductCatalogService {
         return productRepository.findTop5ByBrandIdOrderByPublishedAtDesc(id);
     }
 
+    @Transactional
     public ProductCatalog save(ProductCatalog productCatalog) {
         return productRepository.save(productCatalog);
     }
@@ -32,5 +35,12 @@ public class ProductCatalogService {
 
     public Optional<ProductCatalog> findById(Long productId) {
         return productRepository.find(productId);
+    }
+
+    public List<ProductCatalog> findByIds(Collection<Long> productCatalogIds) {
+        if (productCatalogIds == null || productCatalogIds.isEmpty()) {
+            return List.of(); // 빈 목록이 들어오면 빈 리스트 반환
+        }
+        return productRepository.findByIdIn(productCatalogIds);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/ProductDefinition.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/ProductDefinition.java
@@ -1,0 +1,74 @@
+package com.loopers.domain.catalog;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+@Entity
+@Table(name = "product_definition")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductDefinition extends BaseEntity {
+
+    @Column(name = "ref_brand_id", nullable = false)
+    private Long brandId;
+
+    @Column(name = "product_name", nullable = false, length = 250)
+    private String productName;
+
+    // TODO. 설계서 반영
+    @Column(name = "base_price", nullable = false, precision = 12, scale = 2)
+    private BigDecimal basePrice;
+
+    @Column(name = "image_url", length = 2048)
+    private String imageUrl;
+
+    @Column(name = "description")
+    private String description;
+
+    private ProductDefinition(Long brandId, String productName, BigDecimal basePrice, String imageUrl, String description) {
+        validate(brandId, productName, basePrice, imageUrl);
+
+        this.brandId = brandId;
+        this.productName = productName;
+        this.basePrice = basePrice;
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+
+    public static ProductDefinition from (Long brandId, String productName, BigDecimal basePrice, String imageUrl, String description){
+        return new ProductDefinition(
+                brandId, productName, basePrice, imageUrl, description
+        );
+    }
+
+    private void validate(Long brandId, String productName, BigDecimal basePrice, String imageUrl){
+        if (brandId == null)
+            throw new CoreException(ErrorType.BAD_REQUEST, "Brand 정보가 존재하지 않습니다.");
+
+        if (productName == null || productName.length() > 100)
+            throw new CoreException(ErrorType.BAD_REQUEST, "상품 이름은 250자 이내여야 합니다.");
+
+        if (basePrice == null || basePrice.compareTo(BigDecimal.ZERO) <= 0)
+            throw new CoreException(ErrorType.BAD_REQUEST, "상품 가격은 0 이하일 수 없습니다.");
+
+        if (basePrice.compareTo(BigDecimal.valueOf(10_000_000_000L)) >= 0)
+            throw new CoreException(ErrorType.BAD_REQUEST, "상품 가격은 최대 10억 미만으로만 설정 가능합니다.");
+
+        if (imageUrl == null) return;
+        try{
+            new URL(imageUrl).toURI();
+        } catch (MalformedURLException | URISyntaxException e){
+            throw new CoreException(ErrorType.BAD_REQUEST, "올바른 URL 형식이 아닙니다.");
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/ProductRepository.java
@@ -3,6 +3,7 @@ package com.loopers.domain.catalog;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,9 +13,9 @@ public interface ProductRepository {
     List<ProductCatalog> findTop5ByBrandIdOrderByPublishedAtDesc(Long id);
     ProductCatalog save(ProductCatalog product);
 
-//    List<ProductCatalog> findAllById(Long id);
-
     Page<ProductCatalog> findAll(Pageable pageable);
 
     Page<ProductCatalog> findByBrandId(Long id, Pageable pageable);
+
+    List<ProductCatalog> findByIdIn(Collection<Long> ids);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/ProductRepository.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.catalog;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductRepository {
+    long count();
+    Optional<ProductCatalog> find(Long id);
+    List<ProductCatalog> findTop5ByBrandIdOrderByPublishedAtDesc(Long id);
+    ProductCatalog save(ProductCatalog product);
+
+//    List<ProductCatalog> findAllById(Long id);
+
+    Page<ProductCatalog> findAll(Pageable pageable);
+
+    Page<ProductCatalog> findByBrandId(Long id, Pageable pageable);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
@@ -1,0 +1,46 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.BaseAuditableEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "likes")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Like extends BaseAuditableEntity {
+    @EmbeddedId
+    private LikeId id;
+
+    private Like(Long userId, Long productCatalogId) {
+        this.id = new LikeId(userId, productCatalogId);
+    }
+
+    public static Like of(Long userId, Long productCatalogId) {
+        return new Like(userId, productCatalogId);
+    }
+
+    @Embeddable
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    @EqualsAndHashCode
+    public static class LikeId {
+        @Column(name = "ref_user_id", nullable = false)
+        Long userId;
+
+        @Column(name = "ref_product_catalog_id", nullable = false)
+        Long productCatalogId;
+
+        private LikeId(Long userId, Long productCatalogId){
+            this.userId = userId;
+            this.productCatalogId = productCatalogId;
+        }
+
+        public static LikeId of(Long userId, Long productCatalogId) {
+            return new LikeId(userId, productCatalogId);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.like;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface LikeRepository {
+    void save(Like entity);
+    Optional<Like> findById(Like.LikeId id);
+    boolean existsById(Like.LikeId id);
+
+    Page<Like> findByIdUserId(Long userId, Pageable pageable);
+    List<Object[]> countLikesByProductCatalogIds(Collection<Long> productCatalogIds);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -1,0 +1,33 @@
+package com.loopers.domain.like;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class LikeService {
+    private final LikeRepository likeRepository;
+
+    public LikeService(LikeRepository likeRepository) {
+        this.likeRepository = likeRepository;
+    }
+
+    public void save(Long userId, Long productCatalogId) {
+        likeRepository.save(Like.of(userId, productCatalogId));
+    }
+
+    public Optional<Like> find(Long userId, Long productCatalogId) {
+        return likeRepository.findById(Like.LikeId.of(userId, productCatalogId));
+    }
+
+    public boolean existsById(Long userId, Long productCatalogId){
+        return likeRepository.existsById(Like.LikeId.of(userId, productCatalogId));
+    }
+
+    public Page<Like> findByIdUserId(Long userId, Pageable pageable){
+        return likeRepository.findByIdUserId(userId, pageable);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -1,0 +1,78 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Order extends BaseEntity {
+
+    @Column(name = "ref_user_id", nullable = false)
+    String userId;
+
+    @OneToMany(mappedBy = "order", fetch = FetchType.LAZY)
+    List<OrderItem> orderItems = new ArrayList<>();
+
+    @Column(name = "total_order_price", nullable = false)
+    BigDecimal totalOrderPrice;
+
+    @Column(name = "status", nullable = false)
+    String status;
+
+    private Order(String userId, String status){
+        this.userId = userId;
+        this.status = status;
+    }
+
+    public static Order of(String userId, String status){
+        return new Order(userId, status);
+    }
+
+    public void addOrderItem(OrderItem item) {
+        if (item == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"OrderItem은 null이 될 수 없습니다.");
+        }
+        this.orderItems.add(item);
+        item.setOrder(this);
+        calculateTotalPrice();
+    }
+
+    public void removeOrderItem(OrderItem item) {
+        if (item == null) {
+            return;
+        }
+
+        boolean removed = this.orderItems.remove(item);
+        if (removed) {
+            item.setOrder(null);
+            calculateTotalPrice();
+        }
+    }
+
+    public void calculateTotalPrice() {
+        if (this.orderItems == null || this.orderItems.isEmpty()) {
+            this.totalOrderPrice = BigDecimal.ZERO;
+            return;
+        }
+        BigDecimal sum = this.orderItems.stream()
+                .map(OrderItem::getTotalItemPrice)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        this.totalOrderPrice = sum;
+    }
+
+    public void updateStatus(String newStatus) {
+        this.status = newStatus;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
@@ -1,0 +1,96 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "order_item")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class OrderItem extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    Order order;
+
+    @Column(name = "product_sku_id", nullable = false)
+    Long productSkuId;
+    @Column(name = "product_catalog_id", nullable = false)
+    Long productCatalogId;
+
+    @Column(name = "quantity", nullable = false)
+    Long quantity;
+    @Column(name = "total_item_price", nullable = false)
+    BigDecimal totalItemPrice;
+
+    @Column(name = "order_item_product_name", nullable = false)
+    String orderItemProductName;
+    @Column(name = "order_item_unit_price", nullable = false)
+    BigDecimal orderItemUnitPrice;
+
+    private OrderItem(Long productSkuId, Long productCatalogId, Long quantity,
+                     BigDecimal orderItemUnitPrice, String orderItemProductName) {
+
+        validate(quantity, orderItemUnitPrice);
+
+        this.productSkuId = productSkuId;
+        this.productCatalogId = productCatalogId;
+        this.quantity = quantity;
+        this.orderItemUnitPrice = orderItemUnitPrice;
+        this.orderItemProductName = orderItemProductName;
+
+        calculateTotalItemPrice();
+    }
+
+    public static OrderItem of(Long productSkuId, Long productCatalogId, Long quantity,
+                               BigDecimal orderItemUnitPrice, String orderItemProductName) {
+        return new OrderItem(productSkuId, productCatalogId, quantity,
+                            orderItemUnitPrice, orderItemProductName);
+    }
+
+    public void validate(Long quantity, BigDecimal orderItemUnitPrice){
+        if(quantity == null || quantity < 0){
+            throw new CoreException(ErrorType.BAD_REQUEST, "수량은 0보다 작을 수 없습니다.");
+        }
+
+        if (orderItemUnitPrice == null || orderItemUnitPrice.compareTo(BigDecimal.ZERO) < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "단가는 0보다 작을 수 없습니다.");
+        }
+    }
+
+    public void updateQuantity(Long newQuantity) {
+        if (newQuantity == null || newQuantity < 0) {
+            throw new IllegalArgumentException("수량은 0보다 작을 수 없습니다.");
+        }
+        this.quantity = newQuantity;
+        calculateTotalItemPrice();
+    }
+
+    public void updateUnitPrice(BigDecimal newUnitPrice) {
+        if (newUnitPrice == null || newUnitPrice.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("단가는 0보다 작을 수 없습니다.");
+        }
+        this.orderItemUnitPrice = newUnitPrice;
+        calculateTotalItemPrice();
+    }
+
+    private void calculateTotalItemPrice() {
+        if (this.quantity == null || this.orderItemUnitPrice == null) {
+            this.totalItemPrice = BigDecimal.ZERO; // 또는 예외 처리
+            return;
+        }
+
+        this.totalItemPrice = this.orderItemUnitPrice.multiply(BigDecimal.valueOf(this.quantity));
+    }
+
+    protected void setOrder(Order order){
+        this.order = order;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.order;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface OrderRepository {
+    Order save(Order order);
+    Page<Order> findByUserId(Long userId, Pageable pageable);
+    Optional<Order> findByIdWithOrderItems(Long orderId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -1,0 +1,53 @@
+package com.loopers.domain.order;
+
+import com.loopers.application.order.OrderCreateCommand;
+import com.loopers.application.order.OrderInfo;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    public OrderService(OrderRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    @Transactional
+    public Order createOrder(OrderCreateCommand request) {
+        Order order = Order.of(request.userId(), "PENDING");
+
+        request.items().forEach(itemDto -> {
+            OrderItem orderItem = OrderItem.of(
+                    itemDto.productSkuId(),
+                    itemDto.productCatalogId(),
+                    itemDto.quantity(),
+                    itemDto.unitPrice(),
+                    itemDto.productName()
+            );
+            order.addOrderItem(orderItem);
+        });
+
+        Order savedOrder = orderRepository.save(order);
+        return savedOrder;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<OrderInfo.OrderResponseInfo> getOrderList(Long userId, Pageable pageable) {
+        Page<Order> ordersPage = orderRepository.findByUserId(userId, pageable);
+        return ordersPage.map(OrderInfo.OrderResponseInfo::from);
+    }
+
+    @Transactional(readOnly = true)
+    public OrderInfo.OrderDetailInfo getOrderDetail(Long orderId) {
+        Order order = orderRepository.findByIdWithOrderItems(orderId)
+                .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "주문을 찾을 수 없습니다. orderId: " + orderId));
+
+        return OrderInfo.OrderDetailInfo.from(order);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/ChargePointCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/ChargePointCommand.java
@@ -4,15 +4,17 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.math.BigDecimal;
+
 @ToString
 @Getter
 @AllArgsConstructor
 public class ChargePointCommand {
 
     private String userId;
-    private long chargePoint;
+    private BigDecimal chargePoint;
 
-    public static ChargePointCommand of(String userId, long chargePoint) {
+    public static ChargePointCommand of(String userId, BigDecimal chargePoint) {
         return new ChargePointCommand(userId, chargePoint);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/DeductPointCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/DeductPointCommand.java
@@ -1,0 +1,19 @@
+package com.loopers.domain.point;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+
+@ToString
+@Getter
+@AllArgsConstructor
+public class DeductPointCommand {
+    private String  userId;
+    private BigDecimal deductPoint;
+
+    public static DeductPointCommand of(String userId, BigDecimal deductPoint) {
+        return new DeductPointCommand(userId, deductPoint);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
@@ -1,0 +1,66 @@
+package com.loopers.domain.point;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Entity
+@Table(name = "point",uniqueConstraints = {
+    @UniqueConstraint(name = "uq_user_id", columnNames = "ref_user_id")
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Point extends BaseEntity {
+
+    @Column(name = "ref_user_id", nullable = false)
+    String userId;
+
+    @Column(name = "point", nullable = false, precision = 12, scale = 2)
+    BigDecimal point;
+
+    private Point(String userId, BigDecimal initialPoint) {
+        if (userId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "사용자 ID는 필수입니다.");
+        }
+        if (initialPoint == null || initialPoint.compareTo(BigDecimal.ZERO) < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "초기 포인트는 음수일 수 없습니다.");
+        }
+        this.userId = userId;
+        this.point = initialPoint.setScale(2, RoundingMode.HALF_UP);
+    }
+
+    public static Point from(String userId, BigDecimal initialPoint) {
+        return new Point(userId, initialPoint);
+    }
+
+    public BigDecimal charge(BigDecimal chargePoint){
+        if (chargePoint == null || chargePoint.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "충전 금액은 0보다 커야 합니다.");
+        }
+        this.point = this.point.add(chargePoint).setScale(2, RoundingMode.HALF_UP);
+        return this.point;
+    }
+
+    public BigDecimal deduct(BigDecimal deductPoint){
+        if (deductPoint == null || deductPoint.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "사용할 포인트는 0보다 커야 합니다.");
+        }
+
+        if (this.point.compareTo(deductPoint) < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "포인트가 부족합니다.");
+        }
+
+        this.point = this.point.subtract(deductPoint).setScale(2, RoundingMode.HALF_UP);
+        return this.point;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -1,9 +1,9 @@
 package com.loopers.domain.point;
 
-import com.loopers.domain.user.UserEntity;
-
 import java.util.Optional;
 
 public interface PointRepository {
-    Optional<UserEntity> find(String findId);
+    Optional<Point> find(String findId);
+
+    Point save(Point Entity);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -1,12 +1,12 @@
 package com.loopers.domain.point;
 
 
-import com.loopers.domain.user.UserEntity;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 @Service
@@ -18,15 +18,26 @@ public class PointService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<UserEntity> find(String userId){
+    public Optional<Point> find(String userId){
         return pointRepository.find(userId);
     }
 
+    public Point save(Point point) {
+        return pointRepository.save(point);
+    }
+
     @Transactional
-    public long charge(ChargePointCommand command) {
-        UserEntity user = find(command.getUserId())
+    public BigDecimal charge(ChargePointCommand command) {
+        Point point = find(command.getUserId())
+                .orElseGet(() -> pointRepository.save(Point.from(command.getUserId(), BigDecimal.ZERO)));
+        return point.charge(command.getChargePoint());
+    }
+
+    @Transactional
+    public BigDecimal deduct(DeductPointCommand command){
+        Point point = find(command.getUserId())
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 User 입니다."));
-        return user.charge(command.getChargePoint());
+        return point.deduct(command.getDeductPoint());
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/OptionName.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/OptionName.java
@@ -1,0 +1,53 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import io.micrometer.common.util.StringUtils;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "option_name")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OptionName extends BaseEntity {
+
+    @Column(name = "name", nullable = false, length = 50, unique = true) // 옵션 이름 (색상, 사이즈 등)
+    private String name;
+
+    @Column(name = "description", length = 250)
+    private String description;
+
+    // 양방향 관계 설정 (OptionName -> OptionValue)
+    @OneToMany(mappedBy = "optionName")
+    private List<OptionValue> optionValues = new ArrayList<>();
+
+    private OptionName(String name, String description){
+        validate(name, description);
+        this.name = name;
+        this.description = description;
+    }
+
+    public static OptionName from(String name, String description) {
+        return new OptionName(name, description);
+    }
+
+    private void validate(String name, String description){
+        if (StringUtils.isBlank(name) || name.length() > 50)
+            throw new CoreException(ErrorType.BAD_REQUEST, "옵션 이름은 50자 이내여야 합니다.");
+
+        if (StringUtils.isBlank(description) || description.length() > 250)
+            throw new CoreException(ErrorType.BAD_REQUEST, "옵션 설명은 250자 이내여야 합니다.");
+
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/OptionValue.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/OptionValue.java
@@ -1,0 +1,38 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import io.micrometer.common.util.StringUtils;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "option_value")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OptionValue extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ref_option_name_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private OptionName optionName; // OptionName 엔티티 참조
+
+    @Column(name = "value", nullable = false, length = 100) // 옵션 값 (레드, M, 256GB)
+    private String value;
+
+    private OptionValue(String value){
+        validate(value);
+        this.value = value;
+    }
+
+    public static OptionValue from(String value) {
+        return new OptionValue(value);
+    }
+
+    private void validate(String value){
+        if (StringUtils.isBlank(value) || value.length() > 100)
+            throw new CoreException(ErrorType.BAD_REQUEST, "옵션 값은 100자 이내여야 합니다.");
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/OptionValue.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/OptionValue.java
@@ -17,7 +17,7 @@ public class OptionValue extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ref_option_name_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    private OptionName optionName; // OptionName 엔티티 참조
+    private OptionName optionName;
 
     @Column(name = "value", nullable = false, length = 100) // 옵션 값 (레드, M, 256GB)
     private String value;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSku.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSku.java
@@ -1,0 +1,93 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "product_sku")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ProductSku extends BaseEntity {
+    @Column(name = "ref_product_definition_id", nullable = false)
+    private Long productDefinitionId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private SkuStatus status;
+
+    @Column(name = "unit_price", nullable = false, precision = 12, scale = 2)
+    private BigDecimal unitPrice;
+
+    @Column(name = "image_url", length = 2048)
+    private String imageUrl;
+
+    @OneToMany(mappedBy = "productSku")
+    private List<SkuOption> skuOptions = new ArrayList<>();
+
+    @Getter
+    public enum SkuStatus{
+        AVAILABLE("AVAILABLE", "구매 가능"),
+        OUT_OF_STOCK("OUT_OF_STOCK", "품절"),
+        PRE_ORDER("PRE_ORDER", "예약 판매"),
+        RESTOCKING("RESTOCKING", "재입고 예정"),
+        DISCONTINUED("DISCONTINUED", "판매 중지")
+        ;
+
+        private final String code;
+        private final String description;
+
+        SkuStatus(String code, String description) {
+            this.code = code;
+            this.description = description;
+        }
+    }
+
+
+    public static ProductSku from(List<SkuOption> skuOptions, String imageUrl, BigDecimal unitPrice, SkuStatus status, Long productDefinitionId){
+        return new ProductSku(
+                skuOptions,
+                imageUrl,
+                unitPrice,
+                status,
+                productDefinitionId
+        );
+    }
+
+    private ProductSku(List<SkuOption> skuOptions, String imageUrl, BigDecimal unitPrice, SkuStatus status, Long productDefinitionId) {
+        validate(imageUrl, unitPrice);
+        this.skuOptions = skuOptions;
+        this.imageUrl = imageUrl;
+        this.unitPrice = unitPrice;
+        this.status = status;
+        this.productDefinitionId = productDefinitionId;
+    }
+
+    private void validate(String imageUrl, BigDecimal unitPrice){
+        if (unitPrice == null || unitPrice.compareTo(BigDecimal.ZERO) <= 0)
+            throw new CoreException(ErrorType.BAD_REQUEST, "상품 가격은 0 이하일 수 없습니다.");
+
+        if (unitPrice.compareTo(BigDecimal.valueOf(10_000_000_000L)) >= 0)
+            throw new CoreException(ErrorType.BAD_REQUEST, "상품 가격은 최대 10억 미만으로만 설정 가능합니다.");
+
+        if (imageUrl == null) return;
+        try{
+            new URL(imageUrl).toURI();
+        } catch (MalformedURLException | URISyntaxException e){
+            throw new CoreException(ErrorType.BAD_REQUEST, "올바른 URL 형식이 아닙니다.");
+        }
+    }
+
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSku.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSku.java
@@ -20,8 +20,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ProductSku extends BaseEntity {
-    @Column(name = "ref_product_definition_id", nullable = false)
-    private Long productDefinitionId;
+    @Column(name = "ref_product_catalog_id", nullable = false)
+    private Long productCatalogId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
@@ -55,23 +55,23 @@ public class ProductSku extends BaseEntity {
     }
 
 
-    public static ProductSku from(List<SkuOption> skuOptions, String imageUrl, BigDecimal unitPrice, SkuStatus status, Long productDefinitionId){
+    public static ProductSku from(List<SkuOption> skuOptions, String imageUrl, BigDecimal unitPrice, SkuStatus status, Long productCatalogId){
         return new ProductSku(
                 skuOptions,
                 imageUrl,
                 unitPrice,
                 status,
-                productDefinitionId
+                productCatalogId
         );
     }
 
-    private ProductSku(List<SkuOption> skuOptions, String imageUrl, BigDecimal unitPrice, SkuStatus status, Long productDefinitionId) {
+    private ProductSku(List<SkuOption> skuOptions, String imageUrl, BigDecimal unitPrice, SkuStatus status, Long productCatalogId) {
         validate(imageUrl, unitPrice);
         this.skuOptions = skuOptions;
         this.imageUrl = imageUrl;
         this.unitPrice = unitPrice;
         this.status = status;
-        this.productDefinitionId = productDefinitionId;
+        this.productCatalogId = productCatalogId;
     }
 
     private void validate(String imageUrl, BigDecimal unitPrice){

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.product;
+
+import java.util.List;
+
+public interface ProductSkuRepository {
+    List<ProductSku> findByProductCatalogId(Long id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuRepository.java
@@ -1,7 +1,11 @@
 package com.loopers.domain.product;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface ProductSkuRepository {
     List<ProductSku> findByProductCatalogId(Long id);
+    List<ProductSku> findByIdIn(Collection<Long> skuIds);
+
+    ProductSku save(ProductSku entity);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuService.java
@@ -2,6 +2,7 @@ package com.loopers.domain.product;
 
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
 
 @Service
@@ -14,5 +15,12 @@ public class ProductSkuService {
 
     public List<ProductSku> findByProductCatalogId(Long productId){
         return productSkuRepository.findByProductCatalogId(productId);
+    }
+
+    public List<ProductSku> findByIds(Collection<Long> skuIds) {
+        if (skuIds == null || skuIds.isEmpty()) {
+            return List.of();
+        }
+        return productSkuRepository.findByIdIn(skuIds);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuService.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.product;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProductSkuService {
+    private final ProductSkuRepository productSkuRepository;
+
+    public ProductSkuService(ProductSkuRepository productSkuRepository) {
+        this.productSkuRepository = productSkuRepository;
+    }
+
+    public List<ProductSku> findByProductCatalogId(Long productId){
+        return productSkuRepository.findByProductCatalogId(productId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/SkuOption.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/SkuOption.java
@@ -20,13 +20,13 @@ public class SkuOption extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ref_product_sku_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    private ProductSku productSku; // ProductSku 엔티티 참조
+    private ProductSku productSku;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ref_option_name_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    private OptionName optionName; // OptionName 엔티티 참조
+    private OptionName optionName;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ref_option_value_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    private OptionValue optionValue; // OptionValue 엔티티 참조
+    private OptionValue optionValue;
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/SkuOption.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/SkuOption.java
@@ -1,0 +1,32 @@
+package com.loopers.domain.product;
+
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "sku_option",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"ref_product_sku_id", "ref_option_name_id"}) // 한 SKU에 동일 옵션 이름 중복 방지
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SkuOption extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ref_product_sku_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private ProductSku productSku; // ProductSku 엔티티 참조
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ref_option_name_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private OptionName optionName; // OptionName 엔티티 참조
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ref_option_value_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private OptionValue optionValue; // OptionValue 엔티티 참조
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/stock/Stock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/stock/Stock.java
@@ -1,0 +1,63 @@
+package com.loopers.domain.stock;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "stock", uniqueConstraints = {
+        @UniqueConstraint(name = "uq_product_sku_id", columnNames = "ref_product_sku_id")
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Stock extends BaseEntity {
+
+    @Column(name = "ref_product_sku_id", nullable = false)
+    Long productSkuId;
+
+    @Column(name = "quantity", nullable = false)
+    Long quantity;
+
+    private Stock(Long productSkuId, Long quantity) {
+        this.productSkuId = productSkuId;
+        this.quantity = quantity;
+    }
+
+    private void validate(Long productSkuId, Long quantity){
+        if (productSkuId == null || quantity == null || quantity < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"제품 옵션 ID 는 필수 값입니다.");
+        }
+
+        if(quantity == null || quantity < 0){
+            throw new CoreException(ErrorType.BAD_REQUEST,"수량은 비어있거나 음수일 수 없습니다.");
+        }
+    }
+
+    public static Stock from(Long productSkuId, Long quantity) {
+        return new Stock(productSkuId, quantity);
+    }
+
+    public void increaseStock(long quantity){
+        if (quantity <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"증가시킬 재고 수량은 0보다 커야 합니다.");
+        }
+        this.quantity += quantity;
+    }
+
+    public void decreaseStock(long quantity) {
+        if (quantity <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"감소시킬 재고 수량은 0보다 커야 합니다.");
+        }
+        if (this.quantity - quantity < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"재고가 부족하여 감소시킬 수 없습니다.");
+        }
+        this.quantity -= quantity;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/stock/StockRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/stock/StockRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.stock;
+
+import java.util.Optional;
+
+public interface StockRepository {
+    Optional<Stock> findByProductSkuId(Long id);
+
+    Stock save(Stock stock);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/stock/StockService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/stock/StockService.java
@@ -1,0 +1,30 @@
+package com.loopers.domain.stock;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class StockService {
+    private final StockRepository stockRepository;
+
+    public StockService(StockRepository stockRepository) {
+        this.stockRepository = stockRepository;
+    }
+
+    public Optional<Stock> findStock(Long id) {
+        return stockRepository.findByProductSkuId(id);
+    }
+
+    public void decreaseStock(Long id, Long quantity){
+        stockRepository.findByProductSkuId(id)
+                .ifPresentOrElse(
+                        stock1 -> {stock1.decreaseStock(quantity);},
+                        () -> {
+                            throw new CoreException(ErrorType.BAD_REQUEST, "재고가 존재하지 않는 상품입니다.");
+                        }
+                );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -13,7 +13,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @Getter
 @ToString
-public class UserEntity extends BaseEntity {
+public class User extends BaseEntity {
     @Column(name = "user_id", length = 10)
     private String userId;
 
@@ -33,7 +33,7 @@ public class UserEntity extends BaseEntity {
     @Column(name = "point", nullable = false)
     private long point;
 
-    private UserEntity(String userId, String name, Gender gender, String birth, String email) {
+    private User(String userId, String name, Gender gender, String birth, String email) {
         this.userId = userId;
         this.userName = name;
         this.gender = gender;
@@ -42,9 +42,9 @@ public class UserEntity extends BaseEntity {
         this.point = 0L;
     }
 
-    public static UserEntity from(UserCommand command) {
+    public static User from(UserCommand command) {
         UserValidator.validate(command);
-        return new UserEntity(
+        return new User(
                 command.userId(),
                 command.userName(),
                 command.gender(),
@@ -61,5 +61,14 @@ public class UserEntity extends BaseEntity {
     public long charge(long chargePoint){
         if (chargePoint <= 0) throw new CoreException(ErrorType.BAD_REQUEST, "충전 금액은 0원 이상이어야 합니다.");
         return this.point += chargePoint;
+    }
+
+    public long deduct(long deductPoint){
+        if (deductPoint >= 0) throw new CoreException(ErrorType.BAD_REQUEST, "사용할 포인트는 0원 이상이어야 합니다.");
+
+        if (this.point - deductPoint < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"포인트가 부족합니다.");
+        }
+        return this.point -= deductPoint;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 public record UserCommand (
         String userId,
         String userName,
-        UserEntity.Gender gender,
+        User.Gender gender,
         String birth,
         String email
 ) {
@@ -18,9 +18,9 @@ public record UserCommand (
         );
     }
 
-    private static UserEntity.Gender stringToEnum(String genderStr){
+    private static User.Gender stringToEnum(String genderStr){
         try{
-            return UserEntity.Gender.valueOf(genderStr);
+            return User.Gender.valueOf(genderStr);
         } catch (IllegalArgumentException e){
             log.error("존재하지 않는 성별입니다. Gender = {}.", genderStr);
             throw new CoreException(ErrorType.BAD_REQUEST, "존재하지 않는 성별입니다.");

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -3,6 +3,6 @@ package com.loopers.domain.user;
 import java.util.Optional;
 
 public interface UserRepository {
-    Optional<UserEntity> find(String findId);
-    UserEntity save(UserEntity user);
+    Optional<User> find(String findId);
+    User save(User user);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -15,20 +15,20 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-    public UserEntity save(UserCommand command){
+    public User save(UserCommand command){
         try{
             userRepository.find(command.userId())
                     .ifPresent(e -> {
                         throw new CoreException(ErrorType.CONFLICT, "이미 존재하는 User 입니다.");
                     });
 
-            return userRepository.save(UserEntity.from(command));
+            return userRepository.save(User.from(command));
         } catch (DataIntegrityViolationException e){
             throw new CoreException(ErrorType.CONFLICT, "이미 존재하는 User 입니다.");
         }
     }
 
-    public Optional<UserEntity> find(String userId){
+    public Optional<User> find(String userId){
         return userRepository.find(userId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/BrandJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/BrandJpaRepository.java
@@ -1,10 +1,10 @@
 package com.loopers.infrastructure.catalog;
 
-import com.loopers.domain.catalog.Brand;
+import com.loopers.domain.catalog.BrandCatalog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface BrandJpaRepository extends JpaRepository<Brand, Long> {
-    List<Brand> findAllById(Iterable<Long> ids);
+public interface BrandJpaRepository extends JpaRepository<BrandCatalog, Long> {
+    List<BrandCatalog> findAllById(Iterable<Long> ids);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/BrandJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/BrandJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.catalog;
+
+import com.loopers.domain.catalog.Brand;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BrandJpaRepository extends JpaRepository<Brand, Long> {
+    List<Brand> findAllById(Iterable<Long> ids);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/BrandRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/BrandRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.loopers.infrastructure.catalog;
 
-import com.loopers.domain.catalog.Brand;
+import com.loopers.domain.catalog.BrandCatalog;
 import com.loopers.domain.catalog.BrandRepository;
 import org.springframework.stereotype.Repository;
 
@@ -16,17 +16,17 @@ public class BrandRepositoryImpl implements BrandRepository {
     }
 
     @Override
-    public Optional<Brand> find(Long id) {
+    public Optional<BrandCatalog> find(Long id) {
         return jpaRepository.findById(id);
     }
 
     @Override
-    public Brand save(Brand brand) {
-        return jpaRepository.save(brand);
+    public BrandCatalog save(BrandCatalog brandCatalog) {
+        return jpaRepository.save(brandCatalog);
     }
 
     @Override
-    public List<Brand> findAllById(Iterable<Long> ids) {
+    public List<BrandCatalog> findAllById(Iterable<Long> ids) {
         return jpaRepository.findAllById(ids);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/BrandRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/BrandRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.loopers.infrastructure.catalog;
+
+import com.loopers.domain.catalog.Brand;
+import com.loopers.domain.catalog.BrandRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class BrandRepositoryImpl implements BrandRepository {
+    private final BrandJpaRepository jpaRepository;
+
+    public BrandRepositoryImpl(BrandJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<Brand> find(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public Brand save(Brand brand) {
+        return jpaRepository.save(brand);
+    }
+
+    @Override
+    public List<Brand> findAllById(Iterable<Long> ids) {
+        return jpaRepository.findAllById(ids);
+    }
+
+    @Override
+    public long count() {
+        return jpaRepository.count();
+    }
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/ProductJpaRepository.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.catalog;
+
+import com.loopers.domain.catalog.ProductCatalog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductJpaRepository extends JpaRepository<ProductCatalog, Long> {
+    List<ProductCatalog> findTop5ByBrandIdOrderByPublishedAtDesc(Long id);
+
+    @Query("SELECT p FROM ProductCatalog p " +
+            "WHERE (:#{#brandId == null} = true OR p.brandId = :brandId) " +
+            "ORDER BY p.publishedAt DESC")
+    List<ProductCatalog> findProductsByBrandIdOrAll(@Param("brandId") Long id);
+
+    Optional<ProductCatalog> findById(Long id);
+    Page<ProductCatalog> findAll(Pageable pageable);
+
+    Page<ProductCatalog> findByBrandId(Long id, Pageable pageable);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/ProductJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,4 +23,5 @@ public interface ProductJpaRepository extends JpaRepository<ProductCatalog, Long
     Page<ProductCatalog> findAll(Pageable pageable);
 
     Page<ProductCatalog> findByBrandId(Long id, Pageable pageable);
+    List<ProductCatalog> findByIdIn(Collection<Long> ids);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/ProductRepositoryImpl.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,5 +45,10 @@ public class ProductRepositoryImpl implements ProductRepository {
     @Override
     public Page<ProductCatalog> findByBrandId(Long id, Pageable pageable) {
         return jpaRepository.findByBrandId(id,pageable);
+    }
+
+    @Override
+    public List<ProductCatalog> findByIdIn(Collection<Long> ids) {
+        return jpaRepository.findByIdIn(ids);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/ProductRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.loopers.infrastructure.catalog;
+
+import com.loopers.domain.catalog.ProductCatalog;
+import com.loopers.domain.catalog.ProductRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class ProductRepositoryImpl implements ProductRepository {
+    private final ProductJpaRepository jpaRepository;
+
+    public ProductRepositoryImpl(ProductJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public long count() {
+        return jpaRepository.count();
+    }
+
+    @Override
+    public Optional<ProductCatalog> find(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    public List<ProductCatalog> findTop5ByBrandIdOrderByPublishedAtDesc(Long id){
+        return jpaRepository.findTop5ByBrandIdOrderByPublishedAtDesc(id);
+    }
+
+    @Override
+    public ProductCatalog save(ProductCatalog product) {
+        return jpaRepository.save(product);
+    }
+
+    @Override
+    public Page<ProductCatalog> findAll(Pageable pageable) {
+        return jpaRepository.findAll(pageable);
+    }
+
+    @Override
+    public Page<ProductCatalog> findByBrandId(Long id, Pageable pageable) {
+        return jpaRepository.findByBrandId(id,pageable);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.Like;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface LikeJpaRepository extends JpaRepository<Like, Like.LikeId> {
+    Optional<Like> findById(Like.LikeId id); // JpaRepository 기본 제공
+    boolean existsById(Like.LikeId id); // JpaRepository 기본 제공
+    Page<Like> findByIdUserId(Long userId, Pageable pageable);
+    Long countByIdProductCatalogId(Long productCatalogId);
+
+    @Query("SELECT pl.id.productCatalogId FROM Like pl WHERE pl.id.userId = :userId")
+    Page<Long> findProductCatalogIdsByUserId(@Param("userId") Long userId, Pageable pageable);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.Like;
+import com.loopers.domain.like.LikeRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class LikeRepositoryImpl implements LikeRepository {
+    private final LikeJpaRepository jpaRepository;
+
+    public LikeRepositoryImpl(LikeJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public void save(Like entity) {
+        jpaRepository.save(entity);
+    }
+
+    @Override
+    public Optional<Like> findById(Like.LikeId id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public boolean existsById(Like.LikeId id) {
+        return false;
+    }
+
+    @Override
+    public Page<Like> findByIdUserId(Long userId, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public List<Object[]> countLikesByProductCatalogIds(Collection<Long> productCatalogIds) {
+        return List.of();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -1,0 +1,17 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface OrderJpaRepository extends JpaRepository<Order, Long> {
+    Page<Order> findByUserId(Long userId, Pageable pageable);
+
+    @Query("SELECT o FROM Order o JOIN FETCH o.orderItems WHERE o.id = :orderId AND o.deletedAt IS NULL")
+    Optional<Order> findByIdWithOrderItems(@Param("orderId") Long orderId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class OrderRepositoryImpl implements OrderRepository {
+    private final OrderJpaRepository jpaRepository;
+
+    public OrderRepositoryImpl(OrderJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Order save(Order order) {
+        return jpaRepository.save(order);
+    }
+
+    public Page<Order> findByUserId(Long userId, Pageable pageable){
+        return jpaRepository.findByUserId(userId, pageable);
+    };
+
+    public Optional<Order> findByIdWithOrderItems(Long orderId){
+        return jpaRepository.findByIdWithOrderItems(orderId);
+    };
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,10 +1,10 @@
 package com.loopers.infrastructure.point;
 
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.point.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface PointJpaRepository extends JpaRepository<UserEntity, Long> {
-    Optional<UserEntity> findByUserId(String findId);
+public interface PointJpaRepository extends JpaRepository<Point, Long> {
+    Optional<Point> findByUserId(String userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.loopers.infrastructure.point;
 
+import com.loopers.domain.point.Point;
 import com.loopers.domain.point.PointRepository;
-import com.loopers.domain.user.UserEntity;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -15,7 +15,12 @@ public class PointRepositoryImpl implements PointRepository {
     }
 
     @Override
-    public Optional<UserEntity> find(String findId) {
+    public Optional<Point> find(String findId) {
         return pointJpaRepository.findByUserId(findId);
+    }
+
+    @Override
+    public Point save(Point entity) {
+        return pointJpaRepository.save(entity);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductSkuJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductSkuJpaRepository.java
@@ -1,0 +1,16 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.ProductSku;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ProductSkuJpaRepository extends JpaRepository<ProductSku, Long> {
+    @Query("SELECT ps FROM ProductSku ps " +
+            "LEFT JOIN FETCH ps.skuOptions so " +
+            "LEFT JOIN FETCH so.optionName oname " +
+            "LEFT JOIN FETCH so.optionValue ovalue " +
+            "WHERE ps.productDefinitionId = :productCatalogId") // ProductCatalog의 ID와 연결된 필드명 확인
+    List<ProductSku> findByProductCatalogIdWithAllOptions(Long productCatalogId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductSkuJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductSkuJpaRepository.java
@@ -4,6 +4,7 @@ import com.loopers.domain.product.ProductSku;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface ProductSkuJpaRepository extends JpaRepository<ProductSku, Long> {
@@ -11,6 +12,8 @@ public interface ProductSkuJpaRepository extends JpaRepository<ProductSku, Long>
             "LEFT JOIN FETCH ps.skuOptions so " +
             "LEFT JOIN FETCH so.optionName oname " +
             "LEFT JOIN FETCH so.optionValue ovalue " +
-            "WHERE ps.productDefinitionId = :productCatalogId") // ProductCatalog의 ID와 연결된 필드명 확인
+            "WHERE ps.productCatalogId = :productCatalogId")
     List<ProductSku> findByProductCatalogIdWithAllOptions(Long productCatalogId);
+
+    List<ProductSku> findByIdIn(Collection<Long> ids);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductSkuRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductSkuRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.ProductSku;
+import com.loopers.domain.product.ProductSkuRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class ProductSkuRepositoryImpl implements ProductSkuRepository {
+    private final ProductSkuJpaRepository jpaRepository;
+
+    public ProductSkuRepositoryImpl(ProductSkuJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public List<ProductSku> findByProductCatalogId(Long id) {
+        return jpaRepository.findByProductCatalogIdWithAllOptions(id);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductSkuRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductSkuRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.loopers.domain.product.ProductSku;
 import com.loopers.domain.product.ProductSkuRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 
 @Repository
@@ -17,5 +18,15 @@ public class ProductSkuRepositoryImpl implements ProductSkuRepository {
     @Override
     public List<ProductSku> findByProductCatalogId(Long id) {
         return jpaRepository.findByProductCatalogIdWithAllOptions(id);
+    }
+
+    @Override
+    public List<ProductSku> findByIdIn(Collection<Long> skuIds) {
+        return jpaRepository.findByIdIn(skuIds);
+    }
+
+    @Override
+    public ProductSku save(ProductSku entity) {
+        return jpaRepository.save(entity);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.stock;
+
+import com.loopers.domain.stock.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StockJpaRepository extends JpaRepository<Stock, Long> {
+    Optional<Stock> findByProductSkuId(Long id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.loopers.infrastructure.stock;
+
+import com.loopers.domain.stock.Stock;
+import com.loopers.domain.stock.StockRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class StockRepositoryImpl implements StockRepository {
+
+    private final StockJpaRepository jpaRepository;
+
+    public StockRepositoryImpl(StockJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<Stock> findByProductSkuId(Long id) {
+        return jpaRepository.findByProductSkuId(id);
+    }
+
+    @Override
+    public Stock save(Stock stock) {
+        return jpaRepository.save(stock);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -1,10 +1,10 @@
 package com.loopers.infrastructure.user;
 
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
-    Optional<UserEntity> findByUserId(String findId);
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUserId(String findId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.loopers.infrastructure.user;
 
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,12 +14,12 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public Optional<UserEntity> find(String findId) {
+    public Optional<User> find(String findId) {
         return userJpaRepository.findByUserId(findId);
     }
 
     @Override
-    public UserEntity save(UserEntity user) {
+    public User save(User user) {
         return userJpaRepository.save(user);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/catalog/ProductCatalogV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/catalog/ProductCatalogV1Dto.java
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api.catalog;
+
+import org.springframework.data.domain.Sort;
+
+public class ProductCatalogV1Dto {
+    public record ProductCatalogRequest(
+            int page,
+            int size,
+            ProductCatalogSortBy sortBy,
+            Sort.Direction direction
+    ){
+        public static ProductCatalogRequest of(int page, int size, ProductCatalogSortBy sortBy, Sort.Direction direction){
+            return new ProductCatalogRequest(page, size, sortBy, direction);
+        }
+
+    }
+
+    public enum ProductCatalogSortBy{
+        BASE_PRICE("basePrice"),
+        PUBLISHED_AT("publishedAt");
+
+        private final String propertyName;
+
+        ProductCatalogSortBy(String propertyName) {
+            this.propertyName = propertyName;
+        }
+
+        public String getPropertyName(){
+            return propertyName;
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
@@ -1,0 +1,17 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.interfaces.api.catalog.ProductCatalogV1Dto;
+import org.springframework.data.domain.Sort;
+
+public class LikeV1Dto {
+    public record LikeRequest(
+            int page,
+            int size,
+            ProductCatalogV1Dto.ProductCatalogSortBy sortBy,
+            Sort.Direction direction
+    ){
+        public static LikeV1Dto.LikeRequest of(int page, int size, ProductCatalogV1Dto.ProductCatalogSortBy sortBy, Sort.Direction direction){
+            return new LikeV1Dto.LikeRequest(page, size, sortBy, direction);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.api.order;
+
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+public class OrderV1Dto {
+    public record OrderCreateRequest(
+            List<OrderItemCreateRequest> items
+    ){
+    }
+
+    public record OrderItemCreateRequest(
+            Long productSkuId,
+            Long quantity
+    ){
+    }
+
+    public record OrderSelectRequest(
+            int page,
+            int size,
+            String sortBy,
+            Sort.Direction direction
+    ){
+        public static OrderSelectRequest of(int page, int size){
+            return new OrderSelectRequest(page, size, "updateAt", Sort.Direction.DESC);
+        }
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointController.java
@@ -5,6 +5,8 @@ import com.loopers.application.point.PointInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigDecimal;
+
 @RestController
 public class PointController implements PointV1ApiSpec{
     private final PointFacade pointFacade;
@@ -26,7 +28,7 @@ public class PointController implements PointV1ApiSpec{
     @PostMapping("/api/v1/points/charge")
     @Override
     public ApiResponse<PointV1Dto.UserPointResponse> charge(@RequestHeader("X-USER-ID") String userId, @RequestBody PointV1Dto.ChargePointRequest request) {
-        long chargedPoint = pointFacade.charge(userId, request);
+        BigDecimal chargedPoint = pointFacade.charge(userId, request);
         return ApiResponse.success(new PointV1Dto.UserPointResponse(
                 userId,
                 chargedPoint

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -1,14 +1,16 @@
 package com.loopers.interfaces.api.point;
 
+import java.math.BigDecimal;
+
 public class PointV1Dto {
 
     public record ChargePointRequest(
-            long point
+            BigDecimal point
     ) {
     }
 
     public record UserPointResponse(
             String userId,
-            long point
+            BigDecimal point
     ){}
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/catalog/BrandCatalogIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/catalog/BrandCatalogIntegrationTest.java
@@ -18,14 +18,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @IntegrationTest
 @SpringBootTest
-public class BrandIntegrationTest {
+public class BrandCatalogIntegrationTest {
 
     private final BrandCatalogFacade brandCatalogFacade;
     private final BrandRepository brandRepository;
     private final DatabaseCleanUp databaseCleanUp;
 
     @Autowired
-    public BrandIntegrationTest(BrandCatalogFacade brandCatalogFacade, BrandRepository brandRepository, DatabaseCleanUp databaseCleanUp) {
+    public BrandCatalogIntegrationTest(BrandCatalogFacade brandCatalogFacade, BrandRepository brandRepository, DatabaseCleanUp databaseCleanUp) {
         this.brandCatalogFacade = brandCatalogFacade;
         this.brandRepository = brandRepository;
         this.databaseCleanUp = databaseCleanUp;
@@ -38,18 +38,18 @@ public class BrandIntegrationTest {
 
     @DisplayName("브랜드조회")
     @Nested
-    class RetrieveBrand{
+    class RetrieveBrandCatalog {
         @Test
         @DisplayName("브랜드 정보가 존재하지 않으면 Not Found 오류가 발생합니다.")
         void returnNotFount_whenBrandNotFound(){
             // arrange
-            Brand appleBrand = Brand.from("Apple", "https://example.com/logos/apple.png");
-            Brand samsungBrand = Brand.from("Samsung", "https://example.com/logos/samsung.png");
-            Brand lgBrand = Brand.from("LG", "https://example.com/logos/lg.png");
+            BrandCatalog appleBrandCatalog = BrandCatalog.from("Apple", "https://example.com/logos/apple.png");
+            BrandCatalog samsungBrandCatalog = BrandCatalog.from("Samsung", "https://example.com/logos/samsung.png");
+            BrandCatalog lgBrandCatalog = BrandCatalog.from("LG", "https://example.com/logos/lg.png");
 
-            brandRepository.save(appleBrand);
-            brandRepository.save(samsungBrand);
-            brandRepository.save(lgBrand);
+            brandRepository.save(appleBrandCatalog);
+            brandRepository.save(samsungBrandCatalog);
+            brandRepository.save(lgBrandCatalog);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {

--- a/apps/commerce-api/src/test/java/com/loopers/domain/catalog/BrandCatalogTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/catalog/BrandCatalogTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 
 @UnitTest
-class BrandTest {
+class BrandCatalogTest {
 
     @Test
     @DisplayName("브랜드Name 이 100자가 넘는 경우, BAD_REQUEST 오류를 반환한다.")
@@ -19,7 +19,7 @@ class BrandTest {
         String brandName = "이렇게 긴 문장의 브랜드 네임은 허용되지 않습니다.".repeat(20);
         String logoImg = "https://loppers-ecommerce/cdn/images/brand/1";
         CoreException exception = assertThrows(CoreException.class, () -> {
-            Brand.from(brandName, logoImg);
+            BrandCatalog.from(brandName, logoImg);
         });
         Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
     }
@@ -30,7 +30,7 @@ class BrandTest {
         String brandName = "loopers";
         String logoImg = "aa:bb:cc";
         CoreException exception = assertThrows(CoreException.class, () -> {
-            Brand.from(brandName, logoImg);
+            BrandCatalog.from(brandName, logoImg);
         });
         Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
     }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/catalog/BrandIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/catalog/BrandIntegrationTest.java
@@ -1,0 +1,63 @@
+package com.loopers.domain.catalog;
+
+
+import com.loopers.application.catalog.BrandCatalogFacade;
+import com.loopers.env.IntegrationTest;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@IntegrationTest
+@SpringBootTest
+public class BrandIntegrationTest {
+
+    private final BrandCatalogFacade brandCatalogFacade;
+    private final BrandRepository brandRepository;
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    public BrandIntegrationTest(BrandCatalogFacade brandCatalogFacade, BrandRepository brandRepository, DatabaseCleanUp databaseCleanUp) {
+        this.brandCatalogFacade = brandCatalogFacade;
+        this.brandRepository = brandRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("브랜드조회")
+    @Nested
+    class RetrieveBrand{
+        @Test
+        @DisplayName("브랜드 정보가 존재하지 않으면 Not Found 오류가 발생합니다.")
+        void returnNotFount_whenBrandNotFound(){
+            // arrange
+            Brand appleBrand = Brand.from("Apple", "https://example.com/logos/apple.png");
+            Brand samsungBrand = Brand.from("Samsung", "https://example.com/logos/samsung.png");
+            Brand lgBrand = Brand.from("LG", "https://example.com/logos/lg.png");
+
+            brandRepository.save(appleBrand);
+            brandRepository.save(samsungBrand);
+            brandRepository.save(lgBrand);
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                brandCatalogFacade.getBrandDetailWithProducts(4L);
+            });
+            // asserts
+            Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/catalog/BrandTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/catalog/BrandTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class BrandTest {
 
     @Test
-    @DisplayName("브랜드Name 이 100자가 넘는 경우, BAD_REQUEST 가 발생합니다.")
+    @DisplayName("브랜드Name 이 100자가 넘는 경우, BAD_REQUEST 오류를 반환한다.")
     void returnBadRequest_whenBrandIdNotFound(){
         String brandName = "이렇게 긴 문장의 브랜드 네임은 허용되지 않습니다.".repeat(20);
         String logoImg = "https://loppers-ecommerce/cdn/images/brand/1";
@@ -25,7 +25,7 @@ class BrandTest {
     }
 
     @Test
-    @DisplayName("URL 형식이 맞지 않는 경우, BAD_REQUEST 가 발생합니다.")
+    @DisplayName("URL 형식이 맞지 않는 경우, BAD_REQUEST 오류를 반환한다.")
     void returnBadRequest_whenMalformedURL(){
         String brandName = "loopers";
         String logoImg = "aa:bb:cc";

--- a/apps/commerce-api/src/test/java/com/loopers/domain/catalog/BrandTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/catalog/BrandTest.java
@@ -1,0 +1,38 @@
+package com.loopers.domain.catalog;
+
+import com.loopers.env.UnitTest;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@UnitTest
+class BrandTest {
+
+    @Test
+    @DisplayName("브랜드Name 이 100자가 넘는 경우, BAD_REQUEST 가 발생합니다.")
+    void returnBadRequest_whenBrandIdNotFound(){
+        String brandName = "이렇게 긴 문장의 브랜드 네임은 허용되지 않습니다.".repeat(20);
+        String logoImg = "https://loppers-ecommerce/cdn/images/brand/1";
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Brand.from(brandName, logoImg);
+        });
+        Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("URL 형식이 맞지 않는 경우, BAD_REQUEST 가 발생합니다.")
+    void returnBadRequest_whenMalformedURL(){
+        String brandName = "loopers";
+        String logoImg = "aa:bb:cc";
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Brand.from(brandName, logoImg);
+        });
+        Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/catalog/ProductCatalogIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/catalog/ProductCatalogIntegrationTest.java
@@ -1,0 +1,121 @@
+package com.loopers.domain.catalog;
+
+import com.loopers.application.catalog.ProductCatalogFacade;
+import com.loopers.application.catalog.ProductCatalogInfo;
+import com.loopers.env.IntegrationTest;
+import com.loopers.interfaces.api.catalog.ProductCatalogV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@IntegrationTest
+@SpringBootTest
+public class ProductCatalogIntegrationTest {
+    private final BrandRepository brandRepository;
+    private final ProductRepository productRepository;
+    private final ProductCatalogFacade productCatalogFacade;
+
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    public ProductCatalogIntegrationTest(BrandRepository brandRepository, ProductRepository productRepository, ProductCatalogFacade productCatalogFacade, DatabaseCleanUp databaseCleanUp) {
+        this.brandRepository = brandRepository;
+        this.productRepository = productRepository;
+        this.productCatalogFacade = productCatalogFacade;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("상품 조회")
+    @Nested
+    @Sql(scripts = {"classpath:catalog/catalog-data.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    class RetrieveProduct{
+
+        @Test
+        @DisplayName("없는 브랜드 ID 로 조회 시, Not Found 오류를 반환한다.")
+        void returnNotFound_whenBrandIdNotFound(){
+            assertThat(brandRepository.count()).isEqualTo(3);
+
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                productCatalogFacade.retrieveProductCatalog(
+                        Optional.of(999L),
+                        ProductCatalogV1Dto.ProductCatalogRequest.of(
+                                0, 5, ProductCatalogV1Dto.ProductCatalogSortBy.PUBLISHED_AT, Sort.Direction.DESC
+                        ));
+            });
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("상품 목록 조회 시, 개수만큼 반환한다. BrandId 있을 때")
+        void returnList_whenRetrieveProductCatalogWithBrandId(){
+            assertThat(brandRepository.count()).isEqualTo(3);
+
+            Page<ProductCatalogInfo> productCatalogInfos =  productCatalogFacade.retrieveProductCatalog(
+                    Optional.of(1L),
+                    ProductCatalogV1Dto.ProductCatalogRequest.of(
+                            0, 5, ProductCatalogV1Dto.ProductCatalogSortBy.PUBLISHED_AT, Sort.Direction.DESC
+                    ));
+
+            assertThat(productCatalogInfos.getContent().size()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("상품 목록 조회 시, 개수만큼 반환한다.")
+        void returnList_whenRetrieveProductCatalog(){
+            assertThat(brandRepository.count()).isEqualTo(3);
+
+            Page<ProductCatalogInfo> productCatalogInfos =  productCatalogFacade.retrieveProductCatalog(
+                    Optional.empty(),
+                    ProductCatalogV1Dto.ProductCatalogRequest.of(
+                            0, 10, ProductCatalogV1Dto.ProductCatalogSortBy.PUBLISHED_AT, Sort.Direction.DESC
+                    ));
+
+            assertThat(productCatalogInfos.getContent().size()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("상품 상세 조회 시, 존재하지 않는 상품이면 Not Found 오류를 반환한다.")
+        void returnNotFound_whenProductDetailNotFound(){
+            assertThat(productRepository.count()).isEqualTo(30);
+
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                productCatalogFacade.retrieveProductDetail(999L);
+            });
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("상품 상세 조회 시, 브랜드가 존재하지 않는 상품이면 Not Found 오류를 반환한다.")
+        @Sql(scripts = {"classpath:catalog/catalog-data-one-product.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+        void returnNotFound_whenProductDetailBrandNotFound(){
+            Long productIdWithNoBrand = 1L;
+
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                productCatalogFacade.retrieveProductDetail(productIdWithNoBrand);
+            });
+
+            // 예외 타입 및 메시지 검증
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+            assertThat(exception.getMessage()).contains("브랜드를 찾을 수 없습니다.");
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/catalog/ProductCatalogTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/catalog/ProductCatalogTest.java
@@ -13,10 +13,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 @UnitTest
-class ProductDefinitionTest {
+class ProductCatalogTest {
 
     @Test
-    @DisplayName("Brand ID 가 없으면 BAD_REQUEST 를 반환한다.")
+    @DisplayName("Brand ID 가 없으면 BAD_REQUEST 오류를 반환한다.")
     void returnBadRequest_whenBrandIdNull(){
         Long brandId = null;
         String productName = "loopers_product_1";
@@ -25,13 +25,13 @@ class ProductDefinitionTest {
         String description = "";
 
         CoreException exception = assertThrows(CoreException.class, () -> {
-            ProductDefinition.from(brandId, productName, price, imageUrl, description);
+            ProductCatalog.from(brandId, productName, price, imageUrl, description);
         });
         Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
     }
 
     @Test
-    @DisplayName("상품의 이름이 250자를 넘으면 BAD_REQUEST 를 반환한다.")
+    @DisplayName("상품의 이름이 250자를 넘으면 BAD_REQUEST 오류를 반환한다.")
     void returnBadRequest_whenProductNameOver250(){
         Long brandId = 0L;
         String productName = "상품 이름이 이렇게 길면 안돼요.".repeat(30);
@@ -40,13 +40,13 @@ class ProductDefinitionTest {
         String description = "";
 
         CoreException exception = assertThrows(CoreException.class, () -> {
-            ProductDefinition.from(brandId, productName, price, imageUrl, description);
+            ProductCatalog.from(brandId, productName, price, imageUrl, description);
         });
         Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
     }
 
     @Test
-    @DisplayName("상품의 가격이 10억을 넘으면 BAD_REQUEST 를 반환한다.")
+    @DisplayName("상품의 가격이 10억을 넘으면 BAD_REQUEST 오류를 반환한다.")
     void returnBadRequest_whenPriceOverThanBillion(){
         Long brandId = 0L;
         String productName = "loopers_product_1";
@@ -55,13 +55,13 @@ class ProductDefinitionTest {
         String description = "";
 
         CoreException exception = assertThrows(CoreException.class, () -> {
-            ProductDefinition.from(brandId, productName, price, imageUrl, description);
+            ProductCatalog.from(brandId, productName, price, imageUrl, description);
         });
         Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
     }
 
     @Test
-    @DisplayName("상품의 가격이 0 이하면 BAD_REQUEST 를 반환한다.")
+    @DisplayName("상품의 가격이 0 이하면 BAD_REQUEST 오류를 반환한다.")
     void returnBadRequest_whenPriceLessThanZero(){
         Long brandId = null;
         String productName = "loopers_product_1";
@@ -70,13 +70,13 @@ class ProductDefinitionTest {
         String description = "";
 
         CoreException exception = assertThrows(CoreException.class, () -> {
-            ProductDefinition.from(brandId, productName, price, imageUrl, description);
+            ProductCatalog.from(brandId, productName, price, imageUrl, description);
         });
         Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
     }
 
     @Test
-    @DisplayName("Image URL 이 올바른 형식이 아니면 BAD_REQUEST 를 반환한다.")
+    @DisplayName("Image URL 이 올바른 형식이 아니면 BAD_REQUEST 오류를 반환한다.")
     void returnBadRequest_whenMalformedURL(){
         Long brandId = null;
         String productName = "loopers_product_1";
@@ -85,7 +85,7 @@ class ProductDefinitionTest {
         String description = "";
 
         CoreException exception = assertThrows(CoreException.class, () -> {
-            ProductDefinition.from(brandId, productName, price, imageUrl, description);
+            ProductCatalog.from(brandId, productName, price, imageUrl, description);
         });
         Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
     }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/catalog/ProductDefinitionTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/catalog/ProductDefinitionTest.java
@@ -1,0 +1,92 @@
+package com.loopers.domain.catalog;
+
+import com.loopers.env.UnitTest;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@UnitTest
+class ProductDefinitionTest {
+
+    @Test
+    @DisplayName("Brand ID 가 없으면 BAD_REQUEST 를 반환한다.")
+    void returnBadRequest_whenBrandIdNull(){
+        Long brandId = null;
+        String productName = "loopers_product_1";
+        BigDecimal price = BigDecimal.valueOf(10000L);
+        String imageUrl = "https://loppers-ecommerce/cdn/images/product/1";
+        String description = "";
+
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            ProductDefinition.from(brandId, productName, price, imageUrl, description);
+        });
+        Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("상품의 이름이 250자를 넘으면 BAD_REQUEST 를 반환한다.")
+    void returnBadRequest_whenProductNameOver250(){
+        Long brandId = 0L;
+        String productName = "상품 이름이 이렇게 길면 안돼요.".repeat(30);
+        BigDecimal price = BigDecimal.valueOf(10000L);
+        String imageUrl = "https://loppers-ecommerce/cdn/images/product/1";
+        String description = "";
+
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            ProductDefinition.from(brandId, productName, price, imageUrl, description);
+        });
+        Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("상품의 가격이 10억을 넘으면 BAD_REQUEST 를 반환한다.")
+    void returnBadRequest_whenPriceOverThanBillion(){
+        Long brandId = 0L;
+        String productName = "loopers_product_1";
+        BigDecimal price = BigDecimal.valueOf(10_000_000_000L);
+        String imageUrl = "https://loppers-ecommerce/cdn/images/product/1";
+        String description = "";
+
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            ProductDefinition.from(brandId, productName, price, imageUrl, description);
+        });
+        Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("상품의 가격이 0 이하면 BAD_REQUEST 를 반환한다.")
+    void returnBadRequest_whenPriceLessThanZero(){
+        Long brandId = null;
+        String productName = "loopers_product_1";
+        BigDecimal price = BigDecimal.valueOf(0L);
+        String imageUrl = "https://loppers-ecommerce/cdn/images/product/1";
+        String description = "";
+
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            ProductDefinition.from(brandId, productName, price, imageUrl, description);
+        });
+        Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Image URL 이 올바른 형식이 아니면 BAD_REQUEST 를 반환한다.")
+    void returnBadRequest_whenMalformedURL(){
+        Long brandId = null;
+        String productName = "loopers_product_1";
+        BigDecimal price = BigDecimal.valueOf(10000L);
+        String imageUrl = "loopers/product/1";
+        String description = "";
+
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            ProductDefinition.from(brandId, productName, price, imageUrl, description);
+        });
+        Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeIntegrationTest.java
@@ -1,0 +1,124 @@
+package com.loopers.domain.like;
+
+import com.loopers.application.like.LikeFacade;
+import com.loopers.env.IntegrationTest;
+import com.loopers.utils.DatabaseCleanUp;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@IntegrationTest
+@SpringBootTest
+public class LikeIntegrationTest {
+
+    private final LikeFacade likeFacade;
+    private final LikeRepository likeRepository;
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    public LikeIntegrationTest(LikeFacade likeFacade, LikeRepository likeRepository, DatabaseCleanUp databaseCleanUp) {
+        this.likeFacade = likeFacade;
+        this.likeRepository = likeRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("like Method 는")
+    @Nested
+    class ProductLikeMethod{
+
+        @Test
+        @DisplayName("좋아요 추가 시 여러번 하더라도 동일하게 성공해야 한다.")
+        void shouldBeIdempotent_forLikeAndUnlike(){
+            Long userId = 1L;
+            Long productCatalogId = 1L;
+            final Like.LikeId TEST_LIKE_ID =Like.LikeId.of(userId, productCatalogId);
+            likeFacade.like(userId, productCatalogId);
+
+            Optional<Like> initialLike = likeRepository.findById(TEST_LIKE_ID);
+            assertThat(initialLike).isPresent();
+            assertThat(initialLike.get().getDeletedAt()).isNull();
+            assertThat(initialLike.get().getId().getUserId()).isEqualTo(userId);
+            assertThat(initialLike.get().getId().getProductCatalogId()).isEqualTo(productCatalogId);
+
+            likeFacade.like(userId, productCatalogId);
+
+            // TODO. 이걸 어떻게 확인해야 할까?
+            Optional<Like> finalLike = likeRepository.findById(TEST_LIKE_ID);
+            assertThat(finalLike).isPresent();
+            assertThat(finalLike.get().getDeletedAt()).isNull();
+            assertThat(finalLike.get().getId().getUserId()).isEqualTo(userId);
+            assertThat(finalLike.get().getId().getProductCatalogId()).isEqualTo(productCatalogId);
+        }
+
+        @Test
+        @DisplayName("좋아요가 삭제된 상태인 경우 복원되어야 한다.")
+        void shouldRestoreLike_whenLikeIsSoftDeleted(){
+            Long userId = 1L;
+            Long productCatalogId = 1L;
+            final Like.LikeId TEST_LIKE_ID =Like.LikeId.of(userId, productCatalogId);
+            likeFacade.like(userId, productCatalogId);
+            likeFacade.unlike(userId, productCatalogId);
+
+            Optional<Like> initialLike = likeRepository.findById(TEST_LIKE_ID);
+            assertThat(initialLike).isPresent();
+            assertThat(initialLike.get().getDeletedAt()).isNotNull();
+
+            likeFacade.like(userId, productCatalogId);
+
+            Optional<Like> finalLike = likeRepository.findById(TEST_LIKE_ID);
+            assertThat(finalLike).isPresent();
+            assertThat(finalLike.get().getDeletedAt()).isNull();
+        }
+    }
+
+    @DisplayName("unlike Method 는")
+    @Nested
+    class ProductUnLikeMethod{
+        @Test
+        @DisplayName("좋아요가 활성 상태일 경우, 삭제 상태로 변경한다.")
+        void shouldSoftDeleteLike_whenLikeIsActive() {
+            Long userId = 1L;
+            Long productCatalogId = 1L;
+            final Like.LikeId TEST_LIKE_ID =Like.LikeId.of(userId, productCatalogId);
+            likeFacade.like(userId, productCatalogId);
+
+            Optional<Like> initialLike = likeRepository.findById(TEST_LIKE_ID);
+            assertThat(initialLike).isPresent();
+            assertThat(initialLike.get().getDeletedAt()).isNull();
+
+            likeFacade.unlike(userId, productCatalogId);
+
+            Optional<Like> finalLike = likeRepository.findById(TEST_LIKE_ID);
+            assertThat(finalLike).isPresent();
+            assertThat(finalLike.get().getDeletedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("좋아요가 존재하지 않을 경우, 아무 동작도 하지 않는다.")
+        void shouldNotChange_whenLikeDoesNotExist() {
+            Long userId = 1L;
+            Long productCatalogId = 1L;
+            final Like.LikeId TEST_LIKE_ID =Like.LikeId.of(userId, productCatalogId);
+
+            likeFacade.unlike(userId,productCatalogId);
+
+            Optional<Like> foundLike = likeRepository.findById(TEST_LIKE_ID);
+            assertThat(foundLike).isNotPresent();
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderItemTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderItemTest.java
@@ -1,0 +1,157 @@
+package com.loopers.domain.order;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OrderItemTest {
+    private final Long TEST_SKU_ID = 1L;
+    private final Long TEST_CATALOG_ID = 100L;
+    private final Long INITIAL_QUANTITY = 2L;
+    private final BigDecimal INITIAL_UNIT_PRICE = BigDecimal.valueOf(10000);
+    private final String INITIAL_PRODUCT_NAME = "테스트 상품";
+
+    @Test
+    @DisplayName("OrderItem 생성 시 필드들이 올바르게 초기화되고 총 가격이 계산된다.")
+    void testOrderItemCreation() {
+        // Given & When
+        OrderItem orderItem = OrderItem.of(
+                TEST_SKU_ID,
+                TEST_CATALOG_ID,
+                INITIAL_QUANTITY,
+                INITIAL_UNIT_PRICE,
+                INITIAL_PRODUCT_NAME
+        );
+
+        // Then
+        assertThat(orderItem.getProductSkuId()).isEqualTo(TEST_SKU_ID);
+        assertThat(orderItem.getProductCatalogId()).isEqualTo(TEST_CATALOG_ID);
+        assertThat(orderItem.getQuantity()).isEqualTo(INITIAL_QUANTITY);
+        assertThat(orderItem.getOrderItemUnitPrice()).isEqualByComparingTo(INITIAL_UNIT_PRICE);
+        assertThat(orderItem.getOrderItemProductName()).isEqualTo(INITIAL_PRODUCT_NAME);
+        assertThat(orderItem.getTotalItemPrice()).isEqualByComparingTo(INITIAL_UNIT_PRICE.multiply(BigDecimal.valueOf(INITIAL_QUANTITY))); // 10000 * 2 = 20000
+        assertThat(orderItem.getOrder()).isNull(); // 처음 생성 시 Order와 연결되지 않음
+    }
+
+    @Test
+    @DisplayName("setOrder 메서드로 Order와의 양방향 관계가 설정된다.")
+    void testSetOrderMethod() {
+        // Given
+        OrderItem orderItem = OrderItem.of(
+                TEST_SKU_ID, TEST_CATALOG_ID, INITIAL_QUANTITY, INITIAL_UNIT_PRICE, INITIAL_PRODUCT_NAME);
+        Order order = Order.of("user1", "CREATED"); // Order 엔티티 생성
+
+        // When
+        orderItem.setOrder(order); // OrderItem의 setOrder 호출
+
+        // Then
+        assertThat(orderItem.getOrder()).isEqualTo(order);
+    }
+
+    @Nested
+    @DisplayName("updateQuantity 메서드는")
+    class UpdateQuantityMethod {
+
+        @Test
+        @DisplayName("수량을 변경하고 총 가격을 재계산한다.")
+        void shouldUpdateQuantityAndRecalculateTotalPrice() {
+            // Given
+            OrderItem orderItem = OrderItem.of(
+                    TEST_SKU_ID, TEST_CATALOG_ID, INITIAL_QUANTITY, INITIAL_UNIT_PRICE, INITIAL_PRODUCT_NAME);
+            BigDecimal initialTotalPrice = orderItem.getTotalItemPrice(); // 20000
+
+            Long newQuantity = 5L; // 새로운 수량
+
+            // When
+            orderItem.updateQuantity(newQuantity);
+
+            // Then
+            assertThat(orderItem.getQuantity()).isEqualTo(newQuantity);
+            assertThat(orderItem.getTotalItemPrice()).isEqualByComparingTo(INITIAL_UNIT_PRICE.multiply(BigDecimal.valueOf(newQuantity))); // 10000 * 5 = 50000
+            assertThat(orderItem.getTotalItemPrice()).isNotEqualByComparingTo(initialTotalPrice); // 가격이 변경되었는지 확인
+        }
+
+        @Test
+        @DisplayName("음수 수량으로 변경하려고 하면 IllegalArgumentException을 발생시킨다.")
+        void shouldThrowException_whenUpdatingWithNegativeQuantity() {
+            // Given
+            OrderItem orderItem = OrderItem.of(
+                    TEST_SKU_ID, TEST_CATALOG_ID, INITIAL_QUANTITY, INITIAL_UNIT_PRICE, INITIAL_PRODUCT_NAME);
+
+            // When & Then
+            assertThrows(IllegalArgumentException.class, () -> orderItem.updateQuantity(-1L));
+            assertThrows(IllegalArgumentException.class, () -> orderItem.updateQuantity(null)); // null도 허용하지 않음
+        }
+
+        @Test
+        @DisplayName("수량을 0으로 변경할 수 있고 총 가격이 0이 된다.")
+        void shouldSetQuantityToZeroAndTotalPriceToZero() {
+            // Given
+            OrderItem orderItem = OrderItem.of(
+                    TEST_SKU_ID, TEST_CATALOG_ID, INITIAL_QUANTITY, INITIAL_UNIT_PRICE, INITIAL_PRODUCT_NAME);
+
+            // When
+            orderItem.updateQuantity(0L);
+
+            // Then
+            assertThat(orderItem.getQuantity()).isEqualTo(0L);
+            assertThat(orderItem.getTotalItemPrice()).isEqualByComparingTo(BigDecimal.ZERO);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUnitPrice 메서드는")
+    class UpdateUnitPriceMethod {
+
+        @Test
+        @DisplayName("단가를 변경하고 총 가격을 재계산한다.")
+        void shouldUpdateUnitPriceAndRecalculateTotalPrice() {
+            // Given
+            OrderItem orderItem = OrderItem.of(
+                    TEST_SKU_ID, TEST_CATALOG_ID, INITIAL_QUANTITY, INITIAL_UNIT_PRICE, INITIAL_PRODUCT_NAME);
+            BigDecimal initialTotalPrice = orderItem.getTotalItemPrice(); // 20000
+
+            BigDecimal newUnitPrice = BigDecimal.valueOf(12000); // 새로운 단가
+
+            // When
+            orderItem.updateUnitPrice(newUnitPrice);
+
+            // Then
+            assertThat(orderItem.getOrderItemUnitPrice()).isEqualByComparingTo(newUnitPrice);
+            assertThat(orderItem.getTotalItemPrice()).isEqualByComparingTo(newUnitPrice.multiply(BigDecimal.valueOf(INITIAL_QUANTITY))); // 12000 * 2 = 24000
+            assertThat(orderItem.getTotalItemPrice()).isNotEqualByComparingTo(initialTotalPrice); // 가격이 변경되었는지 확인
+        }
+
+        @Test
+        @DisplayName("음수 단가로 변경하려고 하면 IllegalArgumentException을 발생시킨다.")
+        void shouldThrowException_whenUpdatingWithNegativeUnitPrice() {
+            // Given
+            OrderItem orderItem = OrderItem.of(
+                    TEST_SKU_ID, TEST_CATALOG_ID, INITIAL_QUANTITY, INITIAL_UNIT_PRICE, INITIAL_PRODUCT_NAME);
+
+            // When & Then
+            assertThrows(IllegalArgumentException.class, () -> orderItem.updateUnitPrice(BigDecimal.valueOf(-1)));
+            assertThrows(IllegalArgumentException.class, () -> orderItem.updateUnitPrice(null)); // null도 허용하지 않음
+        }
+
+        @Test
+        @DisplayName("단가를 0으로 변경할 수 있고 총 가격이 0이 된다.")
+        void shouldSetUnitPriceToZeroAndTotalPriceToZero() {
+            // Given
+            OrderItem orderItem = OrderItem.of(
+                    TEST_SKU_ID, TEST_CATALOG_ID, INITIAL_QUANTITY, INITIAL_UNIT_PRICE, INITIAL_PRODUCT_NAME);
+
+            // When
+            orderItem.updateUnitPrice(BigDecimal.ZERO);
+
+            // Then
+            assertThat(orderItem.getOrderItemUnitPrice()).isEqualByComparingTo(BigDecimal.ZERO);
+            assertThat(orderItem.getTotalItemPrice()).isEqualByComparingTo(BigDecimal.ZERO);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
@@ -1,0 +1,204 @@
+package com.loopers.domain.order;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OrderTest {
+
+    private final String TEST_USER_ID = "user1";
+    private final String INITIAL_STATUS = "CREATED";
+
+    @Nested
+    @DisplayName("addOrderItem 메서드는")
+    class AddOrderItemMethod {
+
+        @Test
+        @DisplayName("주문 상품을 추가하고, 총 주문 가격을 업데이트하며, 양방향 관계를 설정한다.")
+        void shouldAddOrderItemAndUpdateTotalPriceAndSetBidirectionalRelation() {
+            // Given
+            Order order = Order.of(TEST_USER_ID, INITIAL_STATUS);
+            OrderItem item1 = OrderItem.of(
+                    10L, 100L, 2L, BigDecimal.valueOf(5000), "상품A"); // totalItemPrice = 10000
+            OrderItem item2 = OrderItem.of(
+                    20L, 200L, 1L, BigDecimal.valueOf(15000), "상품B"); // totalItemPrice = 15000
+
+            // When
+            order.addOrderItem(item1);
+            order.addOrderItem(item2);
+
+            // Then
+            assertThat(order.getOrderItems()).hasSize(2);
+            assertThat(order.getOrderItems()).contains(item1, item2); // 리스트에 추가되었는지 확인
+
+            // 양방향 관계 확인
+            assertThat(item1.getOrder()).isEqualTo(order);
+            assertThat(item2.getOrder()).isEqualTo(order);
+
+            // 총 가격 업데이트 확인 (10000 + 15000 = 25000)
+            assertThat(order.getTotalOrderPrice()).isEqualByComparingTo(BigDecimal.valueOf(25000));
+        }
+
+        @Test
+        @DisplayName("null OrderItem을 추가하려고 하면 IllegalArgumentException을 발생시킨다.")
+        void shouldThrowException_whenAddingNullOrderItem() {
+            // Given
+            Order order = Order.of(TEST_USER_ID, INITIAL_STATUS);
+
+            // When & Then
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                order.addOrderItem(null);
+            });
+            Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("removeOrderItem 메서드는")
+    class RemoveOrderItemMethod {
+
+        @Test
+        @DisplayName("주문 상품을 제거하고, 총 주문 가격을 업데이트하며, 양방향 관계를 해제한다.")
+        void shouldRemoveOrderItemAndUpdateTotalPriceAndUnsetBidirectionalRelation() {
+            // Given
+            Order order = Order.of(TEST_USER_ID, INITIAL_STATUS);
+            OrderItem item1 = OrderItem.of(
+                    10L, 100L, 2L, BigDecimal.valueOf(5000), "상품A");
+            OrderItem item2 = OrderItem.of(
+                    20L, 200L, 1L, BigDecimal.valueOf(15000), "상품B");
+            order.addOrderItem(item1); // 총 가격 10000
+            order.addOrderItem(item2); // 총 가격 25000
+
+            assertThat(order.getOrderItems()).hasSize(2);
+            assertThat(order.getTotalOrderPrice()).isEqualByComparingTo(BigDecimal.valueOf(25000));
+
+            // When
+            order.removeOrderItem(item1); // item1 제거
+
+            // Then
+            assertThat(order.getOrderItems()).hasSize(1);
+            assertThat(order.getOrderItems()).doesNotContain(item1);
+            assertThat(order.getOrderItems()).contains(item2);
+
+            // 양방향 관계 해제 확인
+            assertThat(item1.getOrder()).isNull();
+            assertThat(item2.getOrder()).isEqualTo(order); // 다른 아이템은 그대로
+
+            // 총 가격 업데이트 확인 (25000 - 10000 = 15000)
+            assertThat(order.getTotalOrderPrice()).isEqualByComparingTo(BigDecimal.valueOf(15000));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 주문 상품을 제거하려고 하면 아무것도 변경하지 않는다.")
+        void shouldNotChange_whenRemovingNonExistingOrderItem() {
+            // Given
+            Order order = Order.of(TEST_USER_ID, INITIAL_STATUS);
+            OrderItem item1 = OrderItem.of(
+                    10L, 100L, 2L, BigDecimal.valueOf(5000), "상품A");
+            order.addOrderItem(item1); // 초기 상태: item1 하나만 있음 (총 가격 10000)
+
+            OrderItem nonExistingItem = OrderItem.of(
+                    30L, 300L, 1L, BigDecimal.valueOf(100), "존재하지않는상품"); // 리스트에 없는 아이템
+
+            // When
+            order.removeOrderItem(nonExistingItem);
+
+            // Then
+            assertThat(order.getOrderItems()).hasSize(1); // 크기 변화 없음
+            assertThat(order.getOrderItems()).contains(item1); // item1은 여전히 존재
+            assertThat(order.getTotalOrderPrice()).isEqualByComparingTo(BigDecimal.valueOf(10000)); // 가격 변화 없음
+        }
+
+        @Test
+        @DisplayName("null OrderItem을 제거하려고 하면 아무것도 변경하지 않는다.")
+        void shouldNotChange_whenRemovingNullOrderItem() {
+            // Given
+            Order order = Order.of(TEST_USER_ID, INITIAL_STATUS);
+            OrderItem item1 = OrderItem.of(
+                    10L, 100L, 2L, BigDecimal.valueOf(5000), "상품A");
+            order.addOrderItem(item1);
+
+            // When
+            order.removeOrderItem(null);
+
+            // Then
+            assertThat(order.getOrderItems()).hasSize(1);
+            assertThat(order.getOrderItems()).contains(item1);
+            assertThat(order.getTotalOrderPrice()).isEqualByComparingTo(BigDecimal.valueOf(10000));
+        }
+    }
+
+    @Nested
+    @DisplayName("calculateTotalPrice 메서드는")
+    class CalculateTotalPriceMethod {
+
+        @Test
+        @DisplayName("주문 상품이 없을 때 총 주문 가격을 0으로 설정한다.")
+        void shouldSetZero_whenNoOrderItems() {
+            // Given
+            Order order = Order.of(TEST_USER_ID, INITIAL_STATUS);
+
+            // When (이미 생성자에서 0으로 초기화되지만, 명시적으로 재계산)
+            order.calculateTotalPrice();
+
+            // Then
+            assertThat(order.getTotalOrderPrice()).isEqualByComparingTo(BigDecimal.ZERO);
+        }
+
+        @Test
+        @DisplayName("주문 상품 추가 후 총 주문 가격을 올바르게 계산한다.")
+        void shouldCalculateCorrectly_afterAddingItems() {
+            // Given
+            Order order = Order.of(TEST_USER_ID, INITIAL_STATUS);
+            OrderItem item1 = OrderItem.of(10L, 100L, 2L, BigDecimal.valueOf(5000), "상품A"); // 10000
+            OrderItem item2 = OrderItem.of(20L, 200L, 1L, BigDecimal.valueOf(15000), "상품B"); // 15000
+
+            // When
+            order.addOrderItem(item1); // 내부적으로 calculateTotalPrice 호출
+            order.addOrderItem(item2); // 내부적으로 calculateTotalPrice 호출
+
+            // Then
+            assertThat(order.getTotalOrderPrice()).isEqualByComparingTo(BigDecimal.valueOf(25000));
+        }
+
+        @Test
+        @DisplayName("주문 상품 제거 후 총 주문 가격을 올바르게 계산한다.")
+        void shouldCalculateCorrectly_afterRemovingItems() {
+            // Given
+            Order order = Order.of(TEST_USER_ID, INITIAL_STATUS);
+            OrderItem item1 = OrderItem.of(10L, 100L, 2L, BigDecimal.valueOf(5000), "상품A"); // 10000
+            OrderItem item2 = OrderItem.of(20L, 200L, 1L, BigDecimal.valueOf(15000), "상품B"); // 15000
+            order.addOrderItem(item1);
+            order.addOrderItem(item2);
+            assertThat(order.getTotalOrderPrice()).isEqualByComparingTo(BigDecimal.valueOf(25000));
+
+            // When
+            order.removeOrderItem(item1); // 내부적으로 calculateTotalPrice 호출
+
+            // Then
+            assertThat(order.getTotalOrderPrice()).isEqualByComparingTo(BigDecimal.valueOf(15000));
+        }
+    }
+
+    @Test
+    @DisplayName("updateStatus 메서드는 주문 상태를 올바르게 변경한다.")
+    void shouldUpdateStatusCorrectly() {
+        // Given
+        Order order = Order.of(TEST_USER_ID, INITIAL_STATUS);
+        String newStatus = "COMPLETED";
+
+        // When
+        order.updateStatus(newStatus);
+
+        // Then
+        assertThat(order.getStatus()).isEqualTo(newStatus);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointEntityTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointEntityTest.java
@@ -1,7 +1,7 @@
 package com.loopers.domain.point;
 
 import com.loopers.domain.user.UserCommand;
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.User;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
@@ -18,10 +18,10 @@ public class PointEntityTest {
         @DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다.")
         @Test
         void failed_whenChargePointIsLessThanZero(){
-            UserEntity user = UserEntity.from(UserCommand.of(
+            User user = User.from(UserCommand.of(
                     "oong",
                     "오옹",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "2025-07-01",
                     "oo@nn.gg"
             ));

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductSkuTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductSkuTest.java
@@ -1,0 +1,86 @@
+package com.loopers.domain.product;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ProductSkuTest {
+
+    @Test
+    @DisplayName("상품 옵션 가격은 0 이하이거나 10억 이상이면 BAD_REQUST 를 반환한다.")
+    void returnBadRequest_whenOptionPriceOutOfRange(){
+        BigDecimal zeroPrice = BigDecimal.valueOf(0L);
+        BigDecimal minusPrice = BigDecimal.valueOf(-1000L);
+        BigDecimal maxPrice = BigDecimal.valueOf(10_000_000_000L);
+        String imageUrl = "https://loppers-ecommerce/cdn/images/product/1";
+
+
+        CoreException zeroPriceException = assertThrows(CoreException.class, () -> {
+            ProductSku.from(List.of(), imageUrl, zeroPrice, ProductSku.SkuStatus.AVAILABLE, 0L);
+        });
+        CoreException minusPriceException = assertThrows(CoreException.class, () -> {
+            ProductSku.from(List.of(), imageUrl, minusPrice, ProductSku.SkuStatus.AVAILABLE, 0L);
+        });
+        CoreException maxPriceException = assertThrows(CoreException.class, () -> {
+            ProductSku.from(List.of(), imageUrl, maxPrice, ProductSku.SkuStatus.AVAILABLE, 0L);
+        });
+        Assertions.assertThat(zeroPriceException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        Assertions.assertThat(minusPriceException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        Assertions.assertThat(maxPriceException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("상품 이미지 URL 이 URL 형식이 아니면 BAD_REQUST 를 반환한다.")
+    void returnBadRequest_whenMalformedURL(){
+        BigDecimal price = BigDecimal.valueOf(10000L);
+        String imageUrl = "haa.aa.aa";
+
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            ProductSku.from(List.of(), imageUrl, price, ProductSku.SkuStatus.AVAILABLE, 0L);
+        });
+        Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("상품 옵션의 값이 100자 이상이면 BAD_REQUST 를 반환한다.")
+    void returnBadRequest_whenTooLongOptionValue(){
+        String value = "옵션 값 value".repeat(100);
+
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            OptionValue.from(value);
+        });
+        Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("상품 옵션 Name이 50자 이상이면 BAD_REQUST 를 반환한다.")
+    void returnBadRequest_whenTooLongOptionName(){
+        String value = "옵션 Name".repeat(100);
+        String description = "옵션 Name 설명입니다.";
+
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            OptionName.from(value, description);
+        });
+        Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("상품 옵션 설명이 250자 이상이면 BAD_REQUST 를 반환한다.")
+    void returnBadRequest_whenTooLongOptionNameDescription(){
+        String value = "옵션 Name";
+        String description = "옵션 Name 설명입니다.".repeat(100);
+
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            OptionName.from(value, description);
+        });
+        Assertions.assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -120,7 +120,6 @@ public class UserServiceIntegrationTest {
             Optional<UserEntity> userEntity = userService.find(UNKNOWN_USER);
             assertThat(userEntity).isEmpty();
         }
-
     }
 }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -45,15 +45,15 @@ public class UserServiceIntegrationTest {
             UserCommand commnand = UserCommand.of(
                     "oong",
                     "오옹",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "2025-06-01",
                     "oong@oo.ng"
             );
 
-            UserEntity user = userService.save(commnand);
+            User user = userService.save(commnand);
 
             verify(userRepository, times(1)).find(any(String.class));
-            verify(userRepository, times(1)).save(any(UserEntity.class));
+            verify(userRepository, times(1)).save(any(User.class));
             assertNotNull(user);
             assertEquals("oong", user.getUserId());
             assertEquals("오옹", user.getUserName());
@@ -65,7 +65,7 @@ public class UserServiceIntegrationTest {
             UserCommand command = UserCommand.of(
                     "oong",
                     "오옹",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "2025-06-01",
                     "oong@oo.ng"
             );
@@ -90,7 +90,7 @@ public class UserServiceIntegrationTest {
             userService.save(UserCommand.of(
                     "oong",
                     "오옹",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "2025-06-01",
                     "oong@oo.ng"
             ));
@@ -104,7 +104,7 @@ public class UserServiceIntegrationTest {
         @DisplayName("해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.")
         @Test
         void success_whenFindExistUserId(){
-            Optional<UserEntity> userInfo = userService.find(ENROLLED_USER);
+            Optional<User> userInfo = userService.find(ENROLLED_USER);
 
             assertThat(userInfo)
                     .isPresent()
@@ -117,7 +117,7 @@ public class UserServiceIntegrationTest {
         @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
         @Test
         void throwNullPointException_whenCannotFindUserId(){
-            Optional<UserEntity> userEntity = userService.find(UNKNOWN_USER);
+            Optional<User> userEntity = userService.find(UNKNOWN_USER);
             assertThat(userEntity).isEmpty();
         }
     }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class UserEntityTest {
+public class UserTest {
     @DisplayName("회원 가입 단위 테스트 ")
     @Nested
     class SignUp {
@@ -26,10 +26,10 @@ public class UserEntityTest {
         })
         void throwBadRequestException_whenIdDoesNotMatch(String userId) {
             final CoreException exception = assertThrows(CoreException.class, () -> {
-                UserEntity.from(UserCommand.of(
+                User.from(UserCommand.of(
                         userId,
                         "오옹",
-                        UserEntity.Gender.M,
+                        User.Gender.M,
                         "2025-07-01",
                         "oo@nn.gg"
                 ));
@@ -42,10 +42,10 @@ public class UserEntityTest {
         @Test
         void throwBadRequestException_whenEmailDoesNotMatch() {
             assertThatThrownBy(() -> {
-                UserEntity.from(UserCommand.of(
+                User.from(UserCommand.of(
                         "oong",
                         "오옹",
-                        UserEntity.Gender.M,
+                        User.Gender.M,
                         "2025-07-01",
                         "oo@nn@gg"
                 ));
@@ -56,10 +56,10 @@ public class UserEntityTest {
         @Test
         void throwBadRequestException_whenBirthDoesNotMatch() {
             assertThatThrownBy(() -> {
-                UserEntity.from(UserCommand.of(
+                User.from(UserCommand.of(
                         "oong",
                         "오옹",
-                        UserEntity.Gender.M,
+                        User.Gender.M,
                         "2025.07.01",
                         "oo@nn.gg"
                 ));

--- a/apps/commerce-api/src/test/java/com/loopers/env/E2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/env/E2ETest.java
@@ -1,0 +1,17 @@
+package com.loopers.env;
+
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Test
+@Tag("e2e")
+public @interface E2ETest {
+}

--- a/apps/commerce-api/src/test/java/com/loopers/env/IntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/env/IntegrationTest.java
@@ -1,0 +1,17 @@
+package com.loopers.env;
+
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Test
+@Tag("integration")
+public @interface IntegrationTest {
+}

--- a/apps/commerce-api/src/test/java/com/loopers/env/UnitTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/env/UnitTest.java
@@ -1,0 +1,17 @@
+package com.loopers.env;
+
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Test
+@Tag("unit")
+public @interface UnitTest {
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -1,8 +1,10 @@
 package com.loopers.interfaces.api.point;
 
 
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointService;
 import com.loopers.domain.user.UserCommand;
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.utils.DatabaseCleanUp;
@@ -14,6 +16,8 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 
 
+import java.math.BigDecimal;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -22,12 +26,14 @@ public class PointV1ApiE2ETest {
     private final TestRestTemplate testRestTemplate;
     private final DatabaseCleanUp databaseCleanUp;
     private final UserService userService;
+    private final PointService pointService;
 
     @Autowired
-    public PointV1ApiE2ETest(TestRestTemplate testRestTemplate, DatabaseCleanUp databaseCleanUp, UserService userService) {
+    public PointV1ApiE2ETest(TestRestTemplate testRestTemplate, DatabaseCleanUp databaseCleanUp, UserService userService, PointService pointService) {
         this.testRestTemplate = testRestTemplate;
         this.databaseCleanUp = databaseCleanUp;
         this.userService = userService;
+        this.pointService = pointService;
     }
 
     @AfterEach
@@ -46,10 +52,12 @@ public class PointV1ApiE2ETest {
             userService.save(UserCommand.of(
                     ENROLLED_USER,
                     "오옹",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "2025-06-01",
                     "oong@oo.ng"
             ));
+
+            pointService.save(Point.from(ENROLLED_USER, BigDecimal.valueOf(1000L)));
         }
 
         @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.")
@@ -93,7 +101,7 @@ public class PointV1ApiE2ETest {
             userService.save(UserCommand.of(
                     ENROLLED_USER,
                     "오옹",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "2025-06-01",
                     "oong@oo.ng"
             ));
@@ -105,7 +113,7 @@ public class PointV1ApiE2ETest {
             HttpHeaders headers = new HttpHeaders();
             headers.set("X-USER-ID", ENROLLED_USER);
 
-            PointV1Dto.ChargePointRequest beforeCharge = new PointV1Dto.ChargePointRequest(1000L);
+            PointV1Dto.ChargePointRequest beforeCharge = new PointV1Dto.ChargePointRequest(BigDecimal.valueOf(1000L));
 
             ParameterizedTypeReference<ApiResponse<PointV1Dto.UserPointResponse>> responseType = new ParameterizedTypeReference<>(){};
             ResponseEntity<ApiResponse<PointV1Dto.UserPointResponse>> response =
@@ -113,8 +121,9 @@ public class PointV1ApiE2ETest {
 
             assertAll(
                     () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
-                    () -> assertThat(response.getBody().data().point()).isEqualTo(1000L)
+                    () -> assertThat(response.getBody().data().point()).isEqualByComparingTo(BigDecimal.valueOf(1000L))
             );
+
         }
 
         @DisplayName("존재하지 않는 유저로 요청할 경우, 404 Not Found 응답을 반환한다.")
@@ -123,7 +132,7 @@ public class PointV1ApiE2ETest {
             HttpHeaders headers = new HttpHeaders();
             headers.set("X-USER-ID", "TEST_USER");
 
-            PointV1Dto.ChargePointRequest beforeCharge = new PointV1Dto.ChargePointRequest(1000L);
+            PointV1Dto.ChargePointRequest beforeCharge = new PointV1Dto.ChargePointRequest(BigDecimal.valueOf(1000L));
 
             ParameterizedTypeReference<ApiResponse<PointV1Dto.UserPointResponse>> responseType = new ParameterizedTypeReference<>(){};
             ResponseEntity<ApiResponse<PointV1Dto.UserPointResponse>> response =

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -1,7 +1,7 @@
 package com.loopers.interfaces.api.user;
 
 import com.loopers.domain.user.UserCommand;
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.utils.DatabaseCleanUp;
@@ -101,7 +101,7 @@ class UserV1ApiE2ETest {
             userService.save(UserCommand.of(
                     ENROLLED_USER,
                     "오옹",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "2025-06-01",
                     "oong@oo.ng"
             ));

--- a/apps/commerce-api/src/test/resources/catalog/catalog-data-one-product.sql
+++ b/apps/commerce-api/src/test/resources/catalog/catalog-data-one-product.sql
@@ -1,0 +1,7 @@
+-- 테이블 init
+DELETE FROM product_catalog;
+DELETE FROM brand;
+ALTER TABLE product_catalog AUTO_INCREMENT = 1;
+ALTER TABLE brand AUTO_INCREMENT = 1;
+
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (999, 'Product with No Brand', 110.00, 'https://example.com/puma_wildrider.png', 'Urban-inspired street style.', NOW(), NOW(), NOW());

--- a/apps/commerce-api/src/test/resources/catalog/catalog-data.sql
+++ b/apps/commerce-api/src/test/resources/catalog/catalog-data.sql
@@ -1,0 +1,44 @@
+-- 테이블 init
+DELETE FROM product_catalog;
+DELETE FROM brand;
+ALTER TABLE product_catalog AUTO_INCREMENT = 1;
+ALTER TABLE brand AUTO_INCREMENT = 1;
+
+-- Brand 데이터
+INSERT INTO brand (brand_name, logo_url, created_at, updated_at) VALUES ('Nike', 'https://example.com/nike_logo.png', NOW(), NOW());
+INSERT INTO brand (brand_name, logo_url, created_at, updated_at) VALUES ('Adidas', 'https://example.com/adidas_logo.png', NOW(), NOW());
+INSERT INTO brand (brand_name, logo_url, created_at, updated_at) VALUES ('Puma', 'https://example.com/puma_logo.png', NOW(), NOW());
+
+-- Product 데이터
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (1, 'Nike Air Force 1', 120.00, 'https://example.com/nike_af1.png', 'Classic white sneakers from Nike.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (1, 'Nike Dunk Low', 110.00, 'https://example.com/nike_dunk.png', 'Popular low-top sneakers.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (1, 'Nike Blazer Mid', 95.00, 'https://example.com/nike_blazer.png', 'Vintage-style basketball shoes.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (1, 'Nike React Element 55', 130.00, 'https://example.com/nike_react.png', 'Comfortable everyday sneakers.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (1, 'Nike Joyride Run Flyknit', 180.00, 'https://example.com/nike_joyride.png', 'Innovative running shoes.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (1, 'Nike Metcon 7', 130.00, 'https://example.com/nike_metcon.png', 'Cross-training shoes for intense workouts.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (1, 'Nike ZoomX Invincible Run Flyknit', 180.00, 'https://example.com/nike_zoomx.png', 'Max cushioning for long runs.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (1, 'Nike Pegasus 38', 120.00, 'https://example.com/nike_pegasus.png', 'Reliable everyday running shoes.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (1, 'Nike ACG Mountain Fly Gore-Tex', 220.00, 'https://example.com/nike_acg.png', 'Durable outdoor hiking shoes.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (1, 'Nike Vaporfly 4% Flyknit', 250.00, 'https://example.com/nike_vaporfly.png', 'Elite racing shoes.', NOW(), NOW(), NOW());
+
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (2, 'Adidas Ultraboost 22', 190.00, 'https://example.com/adidas_ultraboost.png', 'Premium running shoes with responsive cushioning.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (2, 'Adidas Stan Smith', 85.00, 'https://example.com/adidas_stansmith.png', 'Iconic classic tennis shoes.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (2, 'Adidas Superstar', 90.00, 'https://example.com/adidas_superstar.png', 'Shell-toe sneakers, a true classic.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (2, 'Adidas NMD_R1', 140.00, 'https://example.com/adidas_nmd.png', 'Modern urban sneakers.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (2, 'Adidas Forum Low', 100.00, 'https://example.com/adidas_forum.png', '80s basketball style.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (2, 'Adidas Gazelle', 80.00, 'https://example.com/adidas_gazelle.png', 'Timeless low-profile trainers.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (2, 'Adidas Terrex Free Hiker', 180.00, 'https://example.com/adidas_terrex.png', 'Lightweight hiking shoes.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (2, 'Adidas Adizero Adios Pro 3', 220.00, 'https://example.com/adidas_adiospro.png', 'Fastest racing shoes for competition.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (2, 'Adidas Continental 80', 80.00, 'https://example.com/adidas_continental.png', 'Retro fitness-inspired shoes.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (2, 'Adidas Campus 80s', 90.00, 'https://example.com/adidas_campus.png', 'Classic suede sneakers.', NOW(), NOW(), NOW());
+
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (3, 'Puma Suede Classic', 70.00, 'https://example.com/puma_suede.png', 'Iconic suede sneakers.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (3, 'Puma RS-X', 110.00, 'https://example.com/puma_rsx.png', 'Chunky retro-inspired sneakers.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (3, 'Puma Cali Sport', 85.00, 'https://example.com/puma_cali.png', 'Platform sneakers for a fashion statement.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (3, 'Puma Future Rider Play On', 90.00, 'https://example.com/puma_futurerider.png', 'Colorful and comfortable sneakers.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (3, 'Puma RS-Fast', 120.00, 'https://example.com/puma_rsfast.png', 'Sleek and dynamic sneakers.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (3, 'Puma Mirage Mox', 100.00, 'https://example.com/puma_mirage.png', 'Inspired by DJ culture.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (3, 'Puma Court Star', 75.00, 'https://example.com/puma_courtstar.png', 'Classic tennis court style.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (3, 'Puma Clyde', 80.00, 'https://example.com/puma_clyde.png', 'Basketball legend Walt "Clyde" Frazier''s signature shoe.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (3, 'Puma King', 150.00, 'https://example.com/puma_king.png', 'Legendary football boots.', NOW(), NOW(), NOW());
+INSERT INTO product_catalog (ref_brand_id, product_name, base_price, image_url, description, published_at, created_at, updated_at) VALUES (3, 'Puma Wild Rider', 110.00, 'https://example.com/puma_wildrider.png', 'Urban-inspired street style.', NOW(), NOW(), NOW());

--- a/modules/jpa/src/main/java/com/loopers/domain/BaseAuditableEntity.java
+++ b/modules/jpa/src/main/java/com/loopers/domain/BaseAuditableEntity.java
@@ -1,0 +1,63 @@
+package com.loopers.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+/**
+ * 생성/수정/삭제 정보를 자동으로 관리해준다.
+ * 재사용성을 위해 이 외의 컬럼이나 동작은 추가하지 않는다.
+ */
+@MappedSuperclass
+@Getter
+public abstract class BaseAuditableEntity {
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private ZonedDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private ZonedDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private ZonedDateTime deletedAt;
+
+    /**
+     * 엔티티의 유효성을 검증한다.
+     * 이 메소드는 PrePersist 및 PreUpdate 시점에 호출된다.
+     */
+    protected void guard() {}
+
+    @PrePersist
+    private void prePersist() {
+        guard();
+
+        ZonedDateTime now = ZonedDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    private void preUpdate() {
+        guard();
+
+        this.updatedAt = ZonedDateTime.now();
+    }
+
+    /**
+     * delete 연산은 멱등하게 동작할 수 있도록 한다. (삭제된 엔티티를 다시 삭제해도 동일한 결과가 나오도록)
+     */
+    public void delete() {
+        if (this.deletedAt == null) {
+            this.deletedAt = ZonedDateTime.now();
+        }
+    }
+
+    /**
+     * restore 연산은 멱등하게 동작할 수 있도록 한다. (삭제되지 않은 엔티티를 복원해도 동일한 결과가 나오도록)
+     */
+    public void restore() {
+        if (this.deletedAt != null) {
+            this.deletedAt = null;
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
상품,브랜드 조회 / 좋아요 / 주문 기능 추가

## 💬 Review Points
이렇게 리뷰 포인트를 작성해도 되는지 잘 모르겠습니다..
다만 솔직하게 이번 라운드는 뭔가 길을 잃은 느낌입니다.
이번 라운드에서 꼭 가져가야 할 부분을 명확히 이해하지 못하고, 원래 만들던 형태로만 개발한 느낌입니다.

1. 도메인간의 의존성을 피하고, 책임을 명확히 하기 위해 애플리케이션 조인을 시도해보았는데
    ProductCatalogFacade 와 같이 Facade 계층에 모든 Service 들을 의존시키고 Flow 를 작성하면서, 비대해진 느낌입니다.
   
    Read 와 Write 모델을 명확히 나누지 않는 Monolithic 에서 애플리케이션 조인을 다르게 표현할 수 있는 방법이 뭐가 있을까요?
    Read/Write 테이블을 따로 나누어 Read 용 테이블에는 미리 모든 데이터를 가지고 있게 할까도 고민했지만 현재 단일 프로젝트에서는 그렇게 하려면 Write 테이블 수정 시에, Read 용 테이블도 같이 수정을 해줘야 하는 방식이라 맞는 방식인지 모르겠어서 적용하지 않았습니다.

2. 동일한 이유로 Facade 계층 즉 애플리케이션을 Thin 하게 하고, 도메인 로직을 뚱뚱하게 하는 방법을 고민했는데
    결국 다른 데이터 즉 Product 상세 조회 시엔 BrandCatalog, ProductCatalog, ProductSku 의 모든 테이블 값을 각각 가져와서 조합하는 방식밖에 생각이 나지 않습니다.
    어딘가에선 데이터를 가져와야 하고 도메인 패키지 내에서 서로 의존하는 방식보다는 Facade 에서 Flow 를 알고 있는게 더 맞다는 생각에 그렇게밖에 개발을 하지 못했습니다..

    도메인 로직을 뚱뚱하게 만들 수 있는 방법을 1가지만 저희 프로젝트를 기반으로 예를 들어주실 수 있을까요?

3. Product 상세 조회 시에 브랜드 이름, 상품 이름과 가격 만 가져오기 위해 다른 Service 들을 의존해서 데이터를 조합해야 합니다.
    불필요해 보이는 작업처럼 느껴지는데 이런 경우에는 해당 컬럼까지 포함된 별도의 Read 모델을 만드는게 맞을까요?

    저희 프로젝트를 기준으로 보면 JPA Entity 를 사용하고 있는 상태에서 테이블은 그대로 두고 Read / Write 용 모델만 별도로 가져갈 수는 없어 보이는데 테이블 자체를 분리하는게 가장 좋은 방안일까요?


## ✅ Checklist
    - [v] 테스트 코드 포함
    - [v] 불필요한 코드 제거