### PR TITLE
Base round 9

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -42,7 +42,7 @@ public class OrderFacade {
     public OrderInfo createOrder(OrderCommand.Create request){
         Map<Long, Long> requestMap = request.toMap();
 
-        List<Product> foundProducts = productService.getProuctListByIds(requestMap.keySet());
+        List<Product> foundProducts = productService.getProuctListBySkuIds(requestMap.keySet());
         Order order = OrderFactory.createOrder(request.userId(), requestMap, foundProducts);
         BigDecimal finalPrice = userCouponService.applyCoupon(
                 UserCouponCommand.Apply.of(

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -15,6 +15,8 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestHeader;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -29,6 +31,7 @@ public class ProductFacade {
 
     private final String PRODUCT_COUNT_PREFIX = "product:count";
     private final String PREFIX_PRODUCT_DETAIL = "product:detail:";
+    private final String RANKING_KEY = "ranking:product:";
 
     public ProductFacade(BrandService brandService, ProductService productService, ProductLikeService productLikeService, RedisCacheWrapper redisCacheWrapper, GlobalEventPublisher globalEventPublisher) {
         this.brandService = brandService;
@@ -64,6 +67,12 @@ public class ProductFacade {
 
     public ProductInfo.DataDetail getProductDetail(@RequestHeader("X-USER-ID") Long userId, ProductQuery.Detail query) {
         ProductInfo.DataDetail cachedDetail = redisCacheWrapper.get(PREFIX_PRODUCT_DETAIL+query.productId(), ProductInfo.DataDetail.class);
+        Long ranking = redisCacheWrapper.getRank(RANKING_KEY+ LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE), query.productId());
+
+        if (cachedDetail.rank() != ranking) {
+            cachedDetail = null;
+            redisCacheWrapper.delete(PREFIX_PRODUCT_DETAIL+query.productId());
+        }
 
         if (cachedDetail != null){
             globalEventPublisher.publish(ProductAppEvent.Clicked.of(userId, query.productId()));
@@ -73,7 +82,7 @@ public class ProductFacade {
             Brand brand = brandService.get(product.getBrandId());
             ProductLike productLike = productLikeService.get(query.productId());
 
-            ProductInfo.DataDetail productDetail = toDataDetail(product, brand, productLike.getLikeCount());
+            ProductInfo.DataDetail productDetail = toDataDetail(product, brand, productLike.getLikeCount(), ranking);
             redisCacheWrapper.set(PREFIX_PRODUCT_DETAIL+query.productId(), productDetail, 10L, TimeUnit.MINUTES);
             globalEventPublisher.publish(ProductAppEvent.Clicked.of(userId, query.productId()));
             return productDetail;
@@ -84,7 +93,7 @@ public class ProductFacade {
         redisCacheWrapper.delete(PREFIX_PRODUCT_DETAIL+query.productId());
     }
 
-    private ProductInfo.DataDetail toDataDetail(Product product, Brand brand, Long likeCount) {
+    private ProductInfo.DataDetail toDataDetail(Product product, Brand brand, Long likeCount, Long ranking) {
         return new ProductInfo.DataDetail(
                 product.getId(),
                 brand.getBrandName(),
@@ -96,7 +105,8 @@ public class ProductFacade {
                 likeCount,
                 product.getSkus().stream()
                         .map(this::toSkuInfo)
-                        .collect(Collectors.toList())
+                        .collect(Collectors.toList()),
+                ranking
         );
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
@@ -25,7 +25,8 @@ public class ProductInfo {
             String description,
             ZonedDateTime publishedAt,
             Long likeCount,
-            List<SkuInfo> skuInfos
+            List<SkuInfo> skuInfos,
+            Long rank
     ){}
 
     public record SkuInfo(

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -7,6 +7,7 @@ import com.loopers.domain.ranking.RankingService;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -24,7 +25,7 @@ public class RankingFacade {
     public List<ProductInfo.DataList> getProductRanking(LocalDate today, int size, int page){
         int start = size * page;
         int end = start + size;
-        Set<Long> rankIds = rankingService.getRange(RANKING_KEY + today, start, end);
+        Set<Long> rankIds = rankingService.getRange(RANKING_KEY + today.format(DateTimeFormatter.ofPattern("yyyyMMdd")), start, end);
         // 조회가 안되는 경우, 고려 필요
         List<ProductListProjectionV2> productList = productService.getProductListByIds(rankIds);
         return productList.stream().map(pj -> {

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -4,42 +4,70 @@ import com.loopers.application.product.ProductInfo;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.product.projections.ProductListProjectionV2;
 import com.loopers.domain.ranking.RankingService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+@Slf4j
 @Component
 public class RankingFacade {
     private final RankingService rankingService;
     private final ProductService productService;
     private final String RANKING_KEY = "ranking:product:";
+    private final String DEFAULT_RANKING = "ranking:product:default";
+
     public RankingFacade(RankingService rankingService, ProductService productService) {
         this.rankingService = rankingService;
         this.productService = productService;
     }
 
-    public List<ProductInfo.DataList> getProductRanking(LocalDate today, int size, int page){
+    public Page<ProductInfo.DataList> getProductRanking(LocalDate today, int size, int page){
         int start = size * page;
         int end = start + size;
-        Set<Long> rankIds = rankingService.getRange(RANKING_KEY + today.format(DateTimeFormatter.ofPattern("yyyyMMdd")), start, end);
+        String rankKey = RANKING_KEY + today.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        Set<Long> rankIds = rankingService.getRange(rankKey, start, end);
+        Long count = rankingService.count(rankKey);
         // 조회가 안되는 경우, 고려 필요
+        if(count == 0){
+            log.info("Redis 에 Ranking 정보가 존재하지 않습니다.");
+            rankIds = rankingService.getRange(DEFAULT_RANKING, start, end);
+        }
+
         List<ProductListProjectionV2> productList = productService.getProductListByIds(rankIds);
-        return productList.stream().map(pj -> {
-                    return new ProductInfo.DataList(
-                            pj.getId(),
-                            pj.getBrandName(),
-                            pj.getProductName(),
-                            pj.getPrice(),
-                            pj.getImageUrl(),
-                            pj.getDescription(),
-                            pj.getPublishedAt(),
-                            pj.getLikeCount()
-                    );
-                })
-                .collect(Collectors.toList());
+
+        return new PageImpl<>(productList, PageRequest.of(page, size), count)
+                .map(pj ->
+                        new ProductInfo.DataList(
+                                pj.getId(),
+                                pj.getBrandName(),
+                                pj.getProductName(),
+                                pj.getPrice(),
+                                pj.getImageUrl(),
+                                pj.getDescription(),
+                                pj.getPublishedAt(),
+                                pj.getLikeCount()
+                        ));
+
+//        return productList.stream().map(pj -> {
+//                    return new ProductInfo.DataList(
+//                            pj.getId(),
+//                            pj.getBrandName(),
+//                            pj.getProductName(),
+//                            pj.getPrice(),
+//                            pj.getImageUrl(),
+//                            pj.getDescription(),
+//                            pj.getPublishedAt(),
+//                            pj.getLikeCount()
+//                    );
+//                })
+//                .collect(Collectors.toList());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -1,0 +1,44 @@
+package com.loopers.application.ranking;
+
+import com.loopers.application.product.ProductInfo;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.projections.ProductListProjectionV2;
+import com.loopers.domain.ranking.RankingService;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class RankingFacade {
+    private final RankingService rankingService;
+    private final ProductService productService;
+    private final String RANKING_KEY = "ranking:product:";
+    public RankingFacade(RankingService rankingService, ProductService productService) {
+        this.rankingService = rankingService;
+        this.productService = productService;
+    }
+
+    public List<ProductInfo.DataList> getProductRanking(LocalDate today, int size, int page){
+        int start = size * page;
+        int end = start + size;
+        Set<Long> rankIds = rankingService.getRange(RANKING_KEY + today, start, end);
+        // 조회가 안되는 경우, 고려 필요
+        List<ProductListProjectionV2> productList = productService.getProductListByIds(rankIds);
+        return productList.stream().map(pj -> {
+                    return new ProductInfo.DataList(
+                            pj.getId(),
+                            pj.getBrandName(),
+                            pj.getProductName(),
+                            pj.getPrice(),
+                            pj.getImageUrl(),
+                            pj.getDescription(),
+                            pj.getPublishedAt(),
+                            pj.getLikeCount()
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingScheduler.java
@@ -1,0 +1,43 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.RankingService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class RankingScheduler {
+    private final RankingService rankingService;
+    private final String RANKING_KEY = "ranking:product:";
+    private final Float CARRY_OVER_WEIGHT = 0.1f;
+
+    public RankingScheduler(RankingService rankingService) {
+        this.rankingService = rankingService;
+    }
+
+    @Scheduled(cron = "0 50 23 * * *")
+    public void carryOver(){
+        String curKey = RANKING_KEY + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String nextKey = RANKING_KEY + LocalDate.now().plusDays(1).format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        int decimalPlaces = 2;
+        float scaleFactor = (float) Math.pow(10, decimalPlaces); // 100.0
+
+        Map<Long, Float> curRanking = rankingService.getRangeWithScore(curKey, 0, 1000);
+        Map<Long, Float> nextRanking = curRanking.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> {
+                            float score = entry.getValue();
+                            long truncatedScore = (long)(score * scaleFactor);
+                            return (float)truncatedScore / scaleFactor;
+                        }
+                ));
+
+        rankingService.add(nextKey, nextRanking);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -27,4 +27,6 @@ public interface ProductRepository {
     Optional<Product> findById(Long productId);
 
     List<Product> findProductsBySkuIds(Collection<Long> skuIds);
+
+    List<ProductListProjectionV2> findProductListByIds(Collection<Long> ids);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -33,7 +33,7 @@ public class ProductService {
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다."));
     }
 
-    public List<Product> getProuctListByIds(Collection<Long> skuIds) {
+    public List<Product> getProuctListBySkuIds(Collection<Long> skuIds) {
         if (skuIds == null || skuIds.isEmpty()) {
             return List.of();
         }
@@ -42,5 +42,9 @@ public class ProductService {
 
     public Long count(){
         return productRepository.count();
+    }
+
+    public List<ProductListProjectionV2> getProductListByIds(Collection<Long> ids){
+        return productRepository.findProductListByIds(ids);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -8,4 +8,6 @@ public interface RankingRepository {
 
     Map<Long, Float> getRangeWithScore(String key, int start, int end);
     void add(String key, Map<Long, Float> map);
+
+    Long count(String key);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -5,5 +5,7 @@ import java.util.Set;
 
 public interface RankingRepository {
     Set<Long> getRange(String key, int start, int end);
-    void add(String key, Map<String, Double> map);
+
+    Map<Long, Float> getRangeWithScore(String key, int start, int end);
+    void add(String key, Map<Long, Float> map);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.ranking;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface RankingRepository {
+    Set<Long> getRange(String key, int start, int end);
+    void add(String key, Map<String, Double> map);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -18,7 +18,11 @@ public class RankingService {
         return repository.getRange(key, start, end);
     }
 
-    public void add(String key, Map<String, Double> map){
+    public Map<Long, Float> getRangeWithScore(String key, int start, int end){
+        return repository.getRangeWithScore(key, start, end);
+    }
+
+    public void add(String key, Map<Long, Float> map){
         repository.add(key, map);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,0 +1,25 @@
+package com.loopers.domain.ranking;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class RankingService {
+    private final RankingRepository repository;
+
+    public RankingService(RankingRepository repository) {
+        this.repository = repository;
+    }
+
+
+    public Set<Long> getRange(String key, int start, int end){
+        return repository.getRange(key, start, end);
+    }
+
+    public void add(String key, Map<String, Double> map){
+        repository.add(key, map);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -26,4 +26,8 @@ public class RankingService {
         repository.add(key, map);
     }
 
+    public Long count(String key){
+        return repository.count(key);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -100,4 +100,20 @@ public interface ProductJpaRepository extends JpaRepository<Product, Long> {
             "LEFT JOIN FETCH so.optionValue ov " +
             "WHERE s.id IN :skuIds")
     List<Product> findProductsBySkuIds(@Param("skuIds") Collection<Long> skuIds);
+
+    @Query(value = """
+            SELECT
+                p.id AS id,
+                b.brand_name AS brandName,
+                p.product_name AS productName,
+                p.price AS price,
+                p.image_url AS imageUrl,
+                p.description AS description,
+                l.like_count AS likeCount
+            FROM product p
+            INNER JOIN product_like l on p.id = l.ref_product_id
+            INNER JOIN brand b on p.ref_brand_id = b.id
+            WHERE p.id IN :ids
+            """, nativeQuery = true)
+    List<ProductListProjectionV2> findProductListByIds(@Param("ids") Collection<Long> ids);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -73,4 +73,9 @@ public class ProductRepositoryImpl implements ProductRepository {
     public List<Product> findProductsBySkuIds(Collection<Long> skuIds) {
         return jpaRepository.findProductsBySkuIds(skuIds);
     }
+
+    @Override
+    public List<ProductListProjectionV2> findProductListByIds(Collection<Long> ids) {
+        return jpaRepository.findProductListByIds(ids);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
@@ -23,11 +23,16 @@ public class RankingRepositoryImpl implements RankingRepository {
         return redisCacheWrapper.getRange(key, start, end);
     }
     @Override
-    public void add(String key, Map<String, Double> map){
+    public Map<Long, Float> getRangeWithScore(String key, int start, int end){
+        return redisCacheWrapper.getRangeWithScore(key, start, end);
+    }
+
+    @Override
+    public void add(String key, Map<Long, Float> map){
         Set<ZSetOperations.TypedTuple<String>> tuples = new HashSet<>();
-        for (Map.Entry<String, Double> entry : map.entrySet()) {
-            String member = entry.getKey();   // 맵의 키가 ZSET의 멤버(String)
-            Double score = entry.getValue();  // 맵의 값이 ZSET의 스코어(Double)
+        for (Map.Entry<Long, Float> entry : map.entrySet()) {
+            String member = String.valueOf(entry.getKey());   // 맵의 키가 ZSET의 멤버(String)
+            Double score = Double.valueOf(entry.getValue());  // 맵의 값이 ZSET의 스코어(Double)
 
             DefaultTypedTuple<String> tuple = new DefaultTypedTuple<>(member, score);
             tuples.add(tuple);

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
@@ -39,4 +39,9 @@ public class RankingRepositoryImpl implements RankingRepository {
         }
         redisCacheWrapper.addZset(key, tuples);
     }
+
+    @Override
+    public Long count(String key){
+        return redisCacheWrapper.count(key);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.config.redis.RedisCacheWrapper;
+import com.loopers.domain.ranking.RankingRepository;
+import org.springframework.data.redis.core.DefaultTypedTuple;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Repository
+public class RankingRepositoryImpl implements RankingRepository {
+    private final RedisCacheWrapper redisCacheWrapper;
+
+    public RankingRepositoryImpl(RedisCacheWrapper redisCacheWrapper) {
+        this.redisCacheWrapper = redisCacheWrapper;
+    }
+
+    @Override
+    public Set<Long> getRange(String key, int start, int end){
+        return redisCacheWrapper.getRange(key, start, end);
+    }
+    @Override
+    public void add(String key, Map<String, Double> map){
+        Set<ZSetOperations.TypedTuple<String>> tuples = new HashSet<>();
+        for (Map.Entry<String, Double> entry : map.entrySet()) {
+            String member = entry.getKey();   // 맵의 키가 ZSET의 멤버(String)
+            Double score = entry.getValue();  // 맵의 값이 ZSET의 스코어(Double)
+
+            DefaultTypedTuple<String> tuple = new DefaultTypedTuple<>(member, score);
+            tuples.add(tuple);
+        }
+        redisCacheWrapper.addZset(key, tuples);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankV1Dto.java
@@ -1,0 +1,33 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.product.ProductInfo;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+public class RankV1Dto {
+    public record Summary(
+            Long id,
+            String brandName,
+            String productName,
+            BigDecimal price,
+            String imageUrl,
+            String description,
+            ZonedDateTime publishedAt,
+            Long likeCount
+    ){
+        public static Summary from(ProductInfo.DataList catalog){
+            return new Summary(
+                    catalog.id(),
+                    catalog.brandName(),
+                    catalog.productName(),
+                    catalog.price(),
+                    catalog.imageUrl(),
+                    catalog.description(),
+                    catalog.publishedAt(),
+                    catalog.likeCount()
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
@@ -3,13 +3,12 @@ package com.loopers.interfaces.api.ranking;
 import com.loopers.application.product.ProductInfo;
 import com.loopers.application.ranking.RankingFacade;
 import com.loopers.interfaces.api.ApiResponse;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Controller
 public class RankingController implements RankingV1ApiSpec{
@@ -21,11 +20,12 @@ public class RankingController implements RankingV1ApiSpec{
 
     @Override
     @GetMapping(value = "/api/v1/rankings", consumes = "applciation/json")
-    public ApiResponse<List<RankV1Dto.Summary>> get(@RequestParam("date") LocalDate today,
+    public ApiResponse<?> get(@RequestParam("date") LocalDate today,
                                                          @RequestParam("size") int size,
                                                          @RequestParam("page") int page) {
-        List<ProductInfo.DataList> result = rankingFacade.getProductRanking(today, size, page);
-        return ApiResponse.success(result.stream().map(RankV1Dto.Summary::from)
-                .collect(Collectors.toList()));
+        Page<ProductInfo.DataList> result = rankingFacade.getProductRanking(today, size, page);
+        return ApiResponse.success(result);
+//        return ApiResponse.success(result.stream().map(RankV1Dto.Summary::from)
+//                .collect(Collectors.toList()));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
@@ -1,0 +1,31 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.product.ProductInfo;
+import com.loopers.application.ranking.RankingFacade;
+import com.loopers.interfaces.api.ApiResponse;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Controller
+public class RankingController implements RankingV1ApiSpec{
+    private final RankingFacade rankingFacade;
+
+    public RankingController(RankingFacade rankingFacade) {
+        this.rankingFacade = rankingFacade;
+    }
+
+    @Override
+    @GetMapping(value = "/api/v1/rankings", consumes = "applciation/json")
+    public ApiResponse<List<RankV1Dto.Summary>> get(@RequestParam("date") LocalDate today,
+                                                         @RequestParam("size") int size,
+                                                         @RequestParam("page") int page) {
+        List<ProductInfo.DataList> result = rankingFacade.getProductRanking(today, size, page);
+        return ApiResponse.success(result.stream().map(RankV1Dto.Summary::from)
+                .collect(Collectors.toList()));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -1,0 +1,26 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "Point V1 API", description = "Point 기능 API 입니다.")
+public interface RankingV1ApiSpec {
+
+    @Operation(
+            summary = "랭킹 조회",
+            description = "오늘 날짜의 랭킹 조회"
+    )
+    ApiResponse<List<RankV1Dto.Summary>> get(
+            @Schema(name = "오늘 날짜", description = "조회할 오늘 랭킹 날짜")
+            LocalDate today,
+            @Schema(name = "Page Size", description = "조회 Page Size")
+            int size,
+            @Schema(name = "Page Num", description = "Page 번호")
+            int page
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Tag(name = "Point V1 API", description = "Point 기능 API 입니다.")
 public interface RankingV1ApiSpec {
@@ -15,7 +14,7 @@ public interface RankingV1ApiSpec {
             summary = "랭킹 조회",
             description = "오늘 날짜의 랭킹 조회"
     )
-    ApiResponse<List<RankV1Dto.Summary>> get(
+    ApiResponse<?> get(
             @Schema(name = "오늘 날짜", description = "조회할 오늘 랭킹 날짜")
             LocalDate today,
             @Schema(name = "Page Size", description = "조회 Page Size")

--- a/apps/commerce-streamer/build.gradle.kts
+++ b/apps/commerce-streamer/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     // add-ons
     implementation(project(":modules:jpa"))
-//    implementation(project(":modules:rediss"))
+    implementation(project(":modules:rediss"))
     implementation(project(":modules:kafka"))
     implementation(project(":modules:event:core"))
     implementation(project(":supports:jackson"))

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metric/AggregateEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metric/AggregateEvent.java
@@ -1,0 +1,9 @@
+package com.loopers.application.metric;
+
+import com.loopers.event.core.EventPayload;
+
+import java.util.List;
+
+public interface AggregateEvent extends EventPayload {
+    List<Long> getProductIds();
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metric/EventDuplicationService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metric/EventDuplicationService.java
@@ -1,0 +1,36 @@
+package com.loopers.application.metric;
+
+import com.loopers.domain.handled.HandledService;
+import com.loopers.event.core.EventSerializer;
+import com.loopers.event.core.EventType;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventDuplicationService {
+    private final HandledService handledService;
+
+    public EventDuplicationService(HandledService handledService) {
+        this.handledService = handledService;
+    }
+
+    public AggregateEvent validAndConvert(ConsumerRecord<String, byte[]> record){
+        if (isAlreadyDone(record.headers().lastHeader("eventId").toString()))
+            return null;
+
+        EventType eventType = EventType.from(
+                record.headers().lastHeader("eventType").value().toString()
+        );
+        AggregateEvent event = (AggregateEvent) EventSerializer.deserialize(
+                // TODO. byte 처리
+                record.value(),
+                eventType.getPayloadClass()
+        );
+        return event;
+    }
+
+    private boolean isAlreadyDone(String envelopId){
+        return handledService.findByEventId(envelopId)
+                .isPresent();
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metric/ProductMetricConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metric/ProductMetricConsumer.java
@@ -8,14 +8,17 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
 public class ProductMetricConsumer {
     private final ProductMetricFacade metricFacade;
+    private final EventDuplicationService duplicationService;
 
-    public ProductMetricConsumer(ProductMetricFacade metricFacade) {
+    public ProductMetricConsumer(ProductMetricFacade metricFacade, EventDuplicationService duplicationService) {
         this.metricFacade = metricFacade;
+        this.duplicationService = duplicationService;
     }
 
     @KafkaListener(
@@ -31,6 +34,28 @@ public class ProductMetricConsumer {
             EventEnvelop<EventPayload> envelop = EventEnvelop.fromJson(message.value());
             metricFacade.handle(envelop);
         }
+
+        acknowledgment.acknowledge(); // manual ack
+    }
+
+    @KafkaListener(
+            topics = {"catalog-events","order-events"},
+            groupId = "product-metric-aggregate",
+            containerFactory = KafkaConfig.BATCH_LISTENER
+    )
+    public void batchConsume(
+            List<ConsumerRecord<String, byte[]>> messages,
+            Acknowledgment acknowledgment
+    ) {
+        // TODO. eventId 를 어디서 처리할껀데?
+        // 이 과정을 별도의 Service 로 빼고, 거기서 바로 검사하는 것도 괜찮을듯?
+        List<AggregateEvent> events = new ArrayList<>();
+        for (ConsumerRecord<String, byte[]> message : messages) {
+            AggregateEvent event = duplicationService.validAndConvert(message);
+            if (event != null)
+                events.add(event);
+        }
+        metricFacade.handle(events);
 
         acknowledgment.acknowledge(); // manual ack
     }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metric/ProductMetricConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metric/ProductMetricConsumer.java
@@ -1,8 +1,7 @@
 package com.loopers.application.metric;
 
 import com.loopers.config.kafka.KafkaConfig;
-import com.loopers.event.core.EventEnvelop;
-import com.loopers.event.core.EventPayload;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
@@ -11,6 +10,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Component
 public class ProductMetricConsumer {
     private final ProductMetricFacade metricFacade;
@@ -21,22 +21,22 @@ public class ProductMetricConsumer {
         this.duplicationService = duplicationService;
     }
 
-    @KafkaListener(
-            topics = {"catalog-events","order-events"},
-            groupId = "product-metric-aggregate",
-            containerFactory = KafkaConfig.BATCH_LISTENER
-    )
-    public void consume(
-            List<ConsumerRecord<String, String>> messages,
-            Acknowledgment acknowledgment
-    ) {
-        for (ConsumerRecord<String, String> message : messages) {
-            EventEnvelop<EventPayload> envelop = EventEnvelop.fromJson(message.value());
-            metricFacade.handle(envelop);
-        }
-
-        acknowledgment.acknowledge(); // manual ack
-    }
+//    @KafkaListener(
+//            topics = {"catalog-events","order-events"},
+//            groupId = "product-metric-aggregate",
+//            containerFactory = KafkaConfig.BATCH_LISTENER
+//    )
+//    public void consume(
+//            List<ConsumerRecord<String, String>> messages,
+//            Acknowledgment acknowledgment
+//    ) {
+//        for (ConsumerRecord<String, String> message : messages) {
+//            EventEnvelop<EventPayload> envelop = EventEnvelop.fromJson(message.value());
+//            metricFacade.handle(envelop);
+//        }
+//
+//        acknowledgment.acknowledge(); // manual ack
+//    }
 
     @KafkaListener(
             topics = {"catalog-events","order-events"},
@@ -47,16 +47,17 @@ public class ProductMetricConsumer {
             List<ConsumerRecord<String, byte[]>> messages,
             Acknowledgment acknowledgment
     ) {
-        // TODO. eventId 를 어디서 처리할껀데?
-        // 이 과정을 별도의 Service 로 빼고, 거기서 바로 검사하는 것도 괜찮을듯?
         List<AggregateEvent> events = new ArrayList<>();
         for (ConsumerRecord<String, byte[]> message : messages) {
-            AggregateEvent event = duplicationService.validAndConvert(message);
-            if (event != null)
-                events.add(event);
+            try{
+                AggregateEvent event = duplicationService.validAndConvert(message);
+                if (event != null)
+                    events.add(event);
+            } catch (RuntimeException e){
+                log.error("Kafka Consume 시 메세지 파싱 오류 발생 {}", message.headers().lastHeader("eventId"));
+            }
         }
         metricFacade.handle(events);
-
-        acknowledgment.acknowledge(); // manual ack
+        acknowledgment.acknowledge();
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metric/ProductMetricFacade.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metric/ProductMetricFacade.java
@@ -3,6 +3,7 @@ package com.loopers.application.metric;
 import com.loopers.domain.handled.HandledService;
 import com.loopers.domain.metric.ProductMetric;
 import com.loopers.domain.metric.ProductMetricService;
+import com.loopers.domain.ranking.RankingService;
 import com.loopers.event.core.EventEnvelop;
 import com.loopers.event.core.EventPayload;
 import com.loopers.event.core.EventType;
@@ -12,14 +13,25 @@ import com.loopers.event.core.payload.ProductAppEvent;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
 @Component
 public class ProductMetricFacade {
     private final HandledService handledService;
     private final ProductMetricService productMetricService;
+    private final RankingService rankingService;
+    private final String VIEW_WEIGHT_KEY = "ranking:weight:view";
+    private final String LIKE_WEIGHT_KEY = "ranking:weight:like";
+    private final String ORDER_WEIGHT_KEY = "ranking:weight:order";
+    private final String RANKING_KEY = "ranking:product:";
 
-    public ProductMetricFacade(HandledService handledService, ProductMetricService productMetricService) {
+    public ProductMetricFacade(HandledService handledService, ProductMetricService productMetricService, RankingService rankingService) {
         this.handledService = handledService;
         this.productMetricService = productMetricService;
+        this.rankingService = rankingService;
     }
 
     @Transactional
@@ -63,6 +75,55 @@ public class ProductMetricFacade {
             default:
                 break;
         }
+    }
+
+    @Transactional
+    public void handle(List<AggregateEvent> aggregateEvents){
+       // TODO. grouping
+        Map<Long, Map<EventType, Long>> aggregatedEvents = aggregateEvents.stream()
+                .flatMap(event -> event.getProductIds().stream()
+                        .map(productId -> new AbstractMap.SimpleEntry<>(productId, event.getType())))
+                .collect(Collectors.groupingBy(
+                        AbstractMap.SimpleEntry::getKey,
+                        Collectors.groupingBy(AbstractMap.SimpleEntry::getValue, Collectors.counting())
+                ));
+
+        // Score 계산
+        Float viewWeight = Optional.ofNullable(rankingService.getWeight(VIEW_WEIGHT_KEY))
+                .orElse(0.1f);
+        Float likeWeight = Optional.ofNullable(rankingService.getWeight(LIKE_WEIGHT_KEY))
+                .orElse(0.5f);
+        Float orderWeight = Optional.ofNullable(rankingService.getWeight(ORDER_WEIGHT_KEY))
+                .orElse(0.8f);
+
+        Map<String, Double> finalScores = new HashMap<>();
+        aggregatedEvents.forEach((productId, actionCounts) -> {
+            long viewCount = actionCounts.getOrDefault(EventType.PRODUCT_DETAIL_CLICKED, 0L);
+            long likeCount = actionCounts.getOrDefault(EventType.PRODUCT_LIKED, 0L);
+            long unlikeCount = actionCounts.getOrDefault(EventType.PRODUCT_UNLIKED, 0L);
+            long orderCount = actionCounts.getOrDefault(EventType.ORDER_COMPLETED, 0L);
+            long orderCanceledCount = actionCounts.getOrDefault(EventType.ORDER_CANCELED, 0L);
+
+            double score = viewCount * viewWeight
+                    + (likeCount - unlikeCount) * likeWeight
+                    + (orderCount - orderCanceledCount) * orderWeight;
+
+            finalScores.put(String.valueOf(productId), score);
+        });
+
+        // Redis 에 저장
+        rankingService.add(RANKING_KEY + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd")), finalScores);
+
+        // Product Metric 에 저장
+        aggregatedEvents.forEach((productId, actionCounts) -> {
+            ProductMetric metric = productMetricService.findById(productId, LocalDate.now());
+
+            metric.increaseViewCount(actionCounts.getOrDefault(EventType.PRODUCT_DETAIL_CLICKED, 0L));
+            metric.increaseLikeCount(actionCounts.getOrDefault(EventType.PRODUCT_LIKED, 0L));
+            metric.decreaseLikeCount(actionCounts.getOrDefault(EventType.PRODUCT_UNLIKED, 0L));
+            metric.increaseSaleCount(actionCounts.getOrDefault(EventType.ORDER_COMPLETED, 0L));
+            metric.decreaseSaleCount(actionCounts.getOrDefault(EventType.ORDER_CANCELED, 0L));
+        });
     }
 
     private boolean isAlreadyDone(String envelopId){

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingWeightScheduler.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingWeightScheduler.java
@@ -1,0 +1,31 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.RankingWeight;
+import com.loopers.domain.ranking.RankingWeightService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class RankingWeightScheduler {
+    private final RankingWeightService rankingWeightService;
+    private final String VIEW_WEIGHT_KEY = "ranking:weight:view";
+    private final String LIKE_WEIGHT_KEY = "ranking:weight:like";
+    private final String ORDER_WEIGHT_KEY = "ranking:weight:order";
+
+    public RankingWeightScheduler(RankingWeightService rankingWeightService) {
+        this.rankingWeightService = rankingWeightService;
+    }
+
+    @Scheduled(cron = "0 * * * * *")
+    public void refreshWeight(){
+        List<RankingWeight> weights = rankingWeightService.getWeights();
+
+        for (RankingWeight weight : weights) {
+            rankingWeightService.addWeight(weight.getName(), weight.getWeight());
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metric/ProductMetric.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metric/ProductMetric.java
@@ -59,6 +59,26 @@ public class ProductMetric extends BaseAuditableEntity {
         this.salesVolume--;
     }
 
+    public void increaseViewCount(long count){
+        this.viewCount += count;
+    }
+
+    public void increaseLikeCount(long count){
+        this.likeCount += count;
+    }
+
+    public void decreaseLikeCount(long count){
+        this.likeCount -= count;
+    }
+
+    public void increaseSaleCount(long count){
+        this.salesVolume += count;
+    }
+
+    public void decreaseSaleCount(long count){
+        this.salesVolume -= count;
+    }
+
 
     @Embeddable
     @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.ranking;
+
+import java.util.Map;
+
+public interface RankingRepository {
+    void add(String key, Map<String, Double> map);
+
+    Float getWeight(String key);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.ranking;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+public class RankingService {
+    private final RankingRepository rankingRepository;
+
+    public RankingService(RankingRepository rankingRepository) {
+        this.rankingRepository = rankingRepository;
+    }
+    public void add(String key, Map<String, Double> map){
+        rankingRepository.add(key, map);
+    }
+
+    public Float getWeight(String key){
+        return rankingRepository.getWeight(key);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingWeight.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingWeight.java
@@ -1,0 +1,19 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.BaseAuditableEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ranking_weight")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class RankingWeight extends BaseAuditableEntity {
+    @Id
+    String name;
+    Float weight;
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingWeightRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingWeightRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.ranking;
+
+import java.util.List;
+
+public interface RankingWeightRepository {
+    List<RankingWeight> getWeights();
+
+    void addWeight(String key, Float weight);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingWeightService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingWeightService.java
@@ -1,0 +1,22 @@
+package com.loopers.domain.ranking;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class RankingWeightService {
+    private final RankingWeightRepository rankingWeightRepository;
+
+    public RankingWeightService(RankingWeightRepository rankingWeightRepository) {
+        this.rankingWeightRepository = rankingWeightRepository;
+    }
+
+    public List<RankingWeight> getWeights(){
+        return rankingWeightRepository.getWeights();
+    }
+
+    public void addWeight(String key, Float weight){
+        rankingWeightRepository.addWeight(key, weight);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/event/payload/LikeAppEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/event/payload/LikeAppEvent.java
@@ -1,0 +1,47 @@
+package com.loopers.event.payload;
+
+import com.loopers.application.metric.AggregateEvent;
+import com.loopers.event.core.EventType;
+
+import java.util.Collections;
+import java.util.List;
+
+public class LikeAppEvent {
+    public record Liked(
+            Long userId,
+            Long productId
+    ) implements AggregateEvent {
+        public static Liked of(Long userId, Long productId){
+            return new Liked(userId, productId);
+        }
+
+        @Override
+        public EventType getType() {
+            return EventType.PRODUCT_LIKED;
+        }
+
+        @Override
+        public List<Long> getProductIds() {
+            return Collections.singletonList(this.productId);
+        }
+    }
+
+    public record UnLiked(
+            Long userId,
+            Long productId
+    ) implements AggregateEvent {
+        public static UnLiked of(Long userId, Long productId){
+            return new UnLiked(userId, productId);
+        }
+
+        @Override
+        public EventType getType() {
+            return EventType.PRODUCT_UNLIKED;
+        }
+
+        @Override
+        public List<Long> getProductIds() {
+            return Collections.singletonList(this.productId);
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/event/payload/OrderAppEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/event/payload/OrderAppEvent.java
@@ -1,0 +1,69 @@
+package com.loopers.event.payload;
+
+import com.loopers.application.metric.AggregateEvent;
+import com.loopers.event.core.EventType;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+public class OrderAppEvent {
+    public record Created(
+            Long orderId,
+            Long userId,
+            Long couponId,
+            BigDecimal finalPrice,
+            Map<Long, Long> orderedItems,
+            Map<Long, Long> orderedProductId
+    ) implements AggregateEvent {
+
+        @Override
+        public EventType getType() {
+            return EventType.ORDER_CREATED;
+        }
+
+        @Override
+        public List<Long> getProductIds() {
+            return orderedProductId.values().stream().toList();
+        }
+
+    }
+
+    public record Completed(
+            Long orderId,
+            Long userId,
+            Long couponId,
+            Map<Long, Long> orderedItems,
+            Map<Long, Long> orderedProductId
+    ) implements AggregateEvent {
+
+        @Override
+        public EventType getType() {
+            return EventType.ORDER_CREATED;
+        }
+
+        @Override
+        public List<Long> getProductIds() {
+            return orderedProductId.values().stream().toList();
+        }
+    }
+
+    public record Canceled(
+            Long orderId,
+            Long userId,
+            Long couponId,
+            Map<Long, Long> orderedItems,
+            Map<Long, Long> orderedProductId
+    ) implements AggregateEvent {
+
+        @Override
+        public EventType getType() {
+            return EventType.ORDER_CREATED;
+        }
+
+        @Override
+        public List<Long> getProductIds() {
+            return orderedProductId.values().stream().toList();
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/event/payload/ProductAppEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/event/payload/ProductAppEvent.java
@@ -1,0 +1,28 @@
+package com.loopers.event.payload;
+
+import com.loopers.application.metric.AggregateEvent;
+import com.loopers.event.core.EventType;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ProductAppEvent {
+    public record Clicked(
+            Long userId,
+            Long productId
+    ) implements AggregateEvent {
+        public static Clicked of(Long userId, Long productId){
+            return new Clicked(userId, productId);
+        }
+
+        @Override
+        public EventType getType() {
+            return EventType.PRODUCT_DETAIL_CLICKED;
+        }
+
+        @Override
+        public List<Long> getProductIds() {
+            return Collections.singletonList(this.productId);
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.config.redis.RedisCacheWrapper;
+import com.loopers.domain.ranking.RankingRepository;
+import org.springframework.data.redis.core.DefaultTypedTuple;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Repository
+public class RankingRepositoryImpl implements RankingRepository {
+    private final RedisCacheWrapper redisCacheWrapper;
+
+    public RankingRepositoryImpl(RedisCacheWrapper redisCacheWrapper) {
+        this.redisCacheWrapper = redisCacheWrapper;
+    }
+
+    @Override
+    public void add(String key, Map<String, Double> map){
+        Set<ZSetOperations.TypedTuple<String>> tuples = new HashSet<>();
+        for (Map.Entry<String, Double> entry : map.entrySet()) {
+            String member = entry.getKey();   // 맵의 키가 ZSET의 멤버(String)
+            Double score = entry.getValue();  // 맵의 값이 ZSET의 스코어(Double)
+
+            DefaultTypedTuple<String> tuple = new DefaultTypedTuple<>(member, score);
+            tuples.add(tuple);
+        }
+        redisCacheWrapper.addZset(key, tuples);
+    }
+
+    @Override
+    public Float getWeight(String key) {
+        return redisCacheWrapper.get(key, Float.class);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingWeightJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingWeightJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingWeight;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RankingWeightJpaRepository extends JpaRepository<RankingWeight, String> {
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingWeightRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingWeightRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.config.redis.RedisCacheWrapper;
+import com.loopers.domain.ranking.RankingWeight;
+import com.loopers.domain.ranking.RankingWeightRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class RankingWeightRepositoryImpl implements RankingWeightRepository {
+    private final RankingWeightJpaRepository jpaRepository;
+    private final RedisCacheWrapper redisCacheWrapper;
+
+    public RankingWeightRepositoryImpl(RankingWeightJpaRepository jpaRepository, RedisCacheWrapper redisCacheWrapper) {
+        this.jpaRepository = jpaRepository;
+        this.redisCacheWrapper = redisCacheWrapper;
+    }
+
+    @Override
+    public List<RankingWeight> getWeights() {
+        return jpaRepository.findAll();
+    }
+
+    @Override
+    public void addWeight(String key, Float weight) {
+        redisCacheWrapper.set(key, weight);
+    }
+}

--- a/modules/event/core/src/main/java/com/loopers/event/core/EventEnvelop.java
+++ b/modules/event/core/src/main/java/com/loopers/event/core/EventEnvelop.java
@@ -27,6 +27,10 @@ public class EventEnvelop<T extends EventPayload> {
         return EventSerializer.serialize(this);
     }
 
+    public String payloadToJson() {
+        return EventSerializer.serialize(this.payload);
+    }
+
     public static EventEnvelop<EventPayload> fromJson(String json) {
         EventRaw eventRaw = EventSerializer.deserialize(json, EventRaw.class);
         if (eventRaw == null) {

--- a/modules/event/producer/src/main/java/com/loopers/event/producer/EventProducer.java
+++ b/modules/event/producer/src/main/java/com/loopers/event/producer/EventProducer.java
@@ -3,12 +3,15 @@ package com.loopers.event.producer;
 import com.loopers.event.core.EventEnvelop;
 import com.loopers.event.producer.domain.DeadEventService;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Component
@@ -22,17 +25,25 @@ class EventProducer {
     }
 
     public void send(EventEnvelop<?> event){
-        try {
-            kafkaTemplate.send(event.getTopic(), event.getEventId(), event.toJson())
-                    .get(1L, TimeUnit.MINUTES);
-        } catch (InterruptedException | ExecutionException e) {
-            log.info("Kafka 이벤트 발행 실패 {}", event);
-            deadEventService.save(event, "Kafka 발행 실패 오류");
-            throw new RuntimeException(e);
-        } catch (TimeoutException e){
-            log.info("Kafka 이벤트 발행 Timeout 발생 {}", event);
-            deadEventService.save(event, "Kafka 발행 Timeout");
-            throw new RuntimeException(e);
-        }
+
+            String payload = event.payloadToJson();
+            List<RecordHeader> headers = List.of(
+                    new RecordHeader("eventType", event.getType().name().getBytes(StandardCharsets.UTF_8)),
+                    new RecordHeader("eventId", event.getEventId().getBytes(StandardCharsets.UTF_8)),
+                    new RecordHeader("createdAt", String.valueOf(event.getCreatedAt()).getBytes(StandardCharsets.UTF_8))
+            );
+
+            ProducerRecord<String, Object> producerRecord = new ProducerRecord<>(event.getTopic(), event.getEventId(), payload);
+            headers.forEach(header -> producerRecord.headers().add(header));
+
+            CompletableFuture<SendResult<String, Object>> future = kafkaTemplate.send(producerRecord);
+            future.whenComplete((result, ex) -> {
+                if (ex == null) {
+                    log.info("Kafka 메세지 전송 성공 {}", event.getEventId());
+                } else {
+                    log.error("Kafka 메세지 전송 실패 {}", event.getEventId());
+                    deadEventService.save(event, "Kafka 발행 실패");
+                }
+            });
     }
 }

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -18,8 +18,8 @@ spring:
     consumer:
       group-id: loopers-default-consumer
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-#      value-deserializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
+#      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       properties:
         enable-auto-commit: false
     listener:

--- a/modules/rediss/src/main/java/com/loopers/config/redis/RedisCacheWrapper.java
+++ b/modules/rediss/src/main/java/com/loopers/config/redis/RedisCacheWrapper.java
@@ -10,6 +10,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -131,6 +132,15 @@ public class RedisCacheWrapper {
         Set<String> range = redisTemplate.opsForZSet().range(key, start, end);
         assert range != null;
         return range.stream().map(Long::parseLong).collect(Collectors.toSet());
+    }
+
+    public Map<Long, Float> getRangeWithScore(String key, int start, int end){
+        Set<ZSetOperations.TypedTuple<String>> range = redisTemplate.opsForZSet().rangeWithScores(key, start, end);
+        assert range != null;
+        return range.stream().collect(Collectors.toMap(
+                tuple -> Long.valueOf(tuple.getValue()),
+                tuple -> tuple.getScore().floatValue()
+        ));
     }
 
 }

--- a/modules/rediss/src/main/java/com/loopers/config/redis/RedisCacheWrapper.java
+++ b/modules/rediss/src/main/java/com/loopers/config/redis/RedisCacheWrapper.java
@@ -128,6 +128,10 @@ public class RedisCacheWrapper {
         redisTemplate.opsForZSet().add(key, tuples);
     }
 
+    public Long count(String key){
+        return redisTemplate.opsForZSet().size(key);
+    }
+
     public Long getRank(String key, Long productId){
         return redisTemplate.opsForZSet().reverseRank(key, productId);
     }

--- a/modules/rediss/src/main/java/com/loopers/config/redis/RedisCacheWrapper.java
+++ b/modules/rediss/src/main/java/com/loopers/config/redis/RedisCacheWrapper.java
@@ -128,8 +128,12 @@ public class RedisCacheWrapper {
         redisTemplate.opsForZSet().add(key, tuples);
     }
 
+    public Long getRank(String key, Long productId){
+        return redisTemplate.opsForZSet().reverseRank(key, productId);
+    }
+
     public Set<Long> getRange(String key, int start, int end){
-        Set<String> range = redisTemplate.opsForZSet().range(key, start, end);
+        Set<String> range = redisTemplate.opsForZSet().reverseRange(key, start, end);
         assert range != null;
         return range.stream().map(Long::parseLong).collect(Collectors.toSet());
     }

--- a/modules/rediss/src/main/java/com/loopers/config/redis/RedisCacheWrapper.java
+++ b/modules/rediss/src/main/java/com/loopers/config/redis/RedisCacheWrapper.java
@@ -6,10 +6,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -120,5 +123,14 @@ public class RedisCacheWrapper {
         }
     }
 
+    public void addZset(String key, Set<ZSetOperations.TypedTuple<String>> tuples){
+        redisTemplate.opsForZSet().add(key, tuples);
+    }
+
+    public Set<Long> getRange(String key, int start, int end){
+        Set<String> range = redisTemplate.opsForZSet().range(key, start, end);
+        assert range != null;
+        return range.stream().map(Long::parseLong).collect(Collectors.toSet());
+    }
 
 }


### PR DESCRIPTION
## 📌 Summary
랭킹을 생성하고, 랭킹 조회 기능을 추가한다.

## 💬 Review Points
1. Kafka Producer Key 값으로 순서 보장
- 현재 구조 상, 브로커가 1개이고 토픽 당 파티션도 1개이기 때문에 별도로 보장을 할 필요는 없지만, 이벤트의 중복처리 방지 등을 위해선 동일 이벤트라면 순서가 보장되어야 한다는 생각이 들었습니다.
- DB 에 이벤트를 영속화하고, 중복 확인을 하기 때문에 다른 Consumer 에서 처리하더라도 중복처리가 가능하지만, Lock 이 필요하다고 느꼈고, DB Lock 에 대한 비용보다는 파티션 키를 기반으로 순서를 보장하는게 더 낮은 비용으로 처리가 가능하다는 생각이 들었습니다.
- **멘토님의 의견은 어떤지 궁금합니다.**

2. Kafka Send 시에 오류가 나면 DLT 에 전송?
- Kafka 에 Send 중에 오류가 난다면 DLT 에 전송하는 방안을 고민해봤었는데, send 시 오류라는건 브로커에 뭔가 오류가 발생했음을 뜻하는 거 같습니다.
- **그렇다면 Kafka 서비스에 오류가 발생했다고 가정하면 DLT 에도 동일하게 전송이 실패할 거 같은데 그런 경우를 방지해서 Kafka 가 아닌 별도의 DLQ 를 사용하시나요?**

3. Kafka Batch Listener 에서 ErrorHandler 를 사용하여, 메세지 처리 중 오류가 발생하면 해당 건만 Skip 처리하고 나머지는 commit 하는 방식으로 처리도 한다 라고 말씀해주셨는데,
- ErrorHandler 의 경우, 메세지 처리 중 오류가 발생하면 Exception 을 잡아주는 것은 맞지만, BatchListener 를 기반으로 List<ConsumerRecord> 를 인자로 받아 처리하는 경우, 메세지 단건별로 정확한 처리가 힘들어 보이는데 맞을까요? 인자로 List 를 받고 개발자가 직접 Loop 를 수행하며 작업을 처리하는 경우, 정확히 어떤 이벤트에서 실패했는지 ErrorHandler 가 알 수 없음
- 위와 같은 이유로 현재는 Loop 내에서 직접 try-catch 를 해주었는데.. 제가 잘못 찾아본것인지 모르겠습니다.

## ✅ Checklist
### Ranking Consumer

- [x]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
- [x]  날짜별로 적재할 키를 계산하는 기능을 만들었다
- [x]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API

- [x]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
- [x]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
- [x]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)
