### PR TITLE
Base round 10

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -31,11 +31,10 @@ public class RankingFacade {
         this.productService = productService;
     }
 
-    public Page<ProductInfo.DataList> getProductRanking(LocalDate today, String period, int size, int page){
+    public Page<ProductInfo.DataList> getProductRanking(LocalDate date, String period, int size, int page){
         int start = size * page;
         int end = start + size;
-//        String rankKey = RANKING_KEY + today.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-        String rankKey = getRankingKey(period);
+        String rankKey = getRankingKey(date, period);
 
         Set<Long> rankIds = rankingService.getRange(rankKey, start, end);
         Long count = rankingService.count(rankKey);
@@ -61,23 +60,22 @@ public class RankingFacade {
                         ));
     }
 
-    private String getRankingKey(String period){
+    private String getRankingKey(LocalDate targetDate, String period){
         Period period1 = Period.valueOf(period);
         String rankingKey = "";
-        LocalDate today = LocalDate.now();
 
         switch (period1){
             case DAILY:
-                rankingKey = RANKING_KEY + today.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+                rankingKey = RANKING_KEY + targetDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
                 break;
             case WEEKLY:
                 WeekFields weekFields = WeekFields.of(Locale.getDefault());
-                int weekNumber = today.get(weekFields.weekOfWeekBasedYear());
-                int year = today.get(weekFields.weekBasedYear());
+                int weekNumber = targetDate.get(weekFields.weekOfWeekBasedYear());
+                int year = targetDate.get(weekFields.weekBasedYear());
                 rankingKey = RANKING_KEY + String.format("%d-%02d", year, weekNumber);
                 break;
             case MONTHLY:
-                YearMonth yearMonth = YearMonth.from(today);
+                YearMonth yearMonth = YearMonth.from(targetDate);
                 rankingKey = RANKING_KEY + yearMonth.format(DateTimeFormatter.ofPattern("yyyy-MM"));
                 break;
             default:

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -11,8 +11,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 @Slf4j
@@ -28,10 +31,11 @@ public class RankingFacade {
         this.productService = productService;
     }
 
-    public Page<ProductInfo.DataList> getProductRanking(LocalDate today, int size, int page){
+    public Page<ProductInfo.DataList> getProductRanking(LocalDate today, String period, int size, int page){
         int start = size * page;
         int end = start + size;
-        String rankKey = RANKING_KEY + today.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+//        String rankKey = RANKING_KEY + today.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String rankKey = getRankingKey(period);
 
         Set<Long> rankIds = rankingService.getRange(rankKey, start, end);
         Long count = rankingService.count(rankKey);
@@ -55,19 +59,38 @@ public class RankingFacade {
                                 pj.getPublishedAt(),
                                 pj.getLikeCount()
                         ));
-
-//        return productList.stream().map(pj -> {
-//                    return new ProductInfo.DataList(
-//                            pj.getId(),
-//                            pj.getBrandName(),
-//                            pj.getProductName(),
-//                            pj.getPrice(),
-//                            pj.getImageUrl(),
-//                            pj.getDescription(),
-//                            pj.getPublishedAt(),
-//                            pj.getLikeCount()
-//                    );
-//                })
-//                .collect(Collectors.toList());
     }
+
+    private String getRankingKey(String period){
+        Period period1 = Period.valueOf(period);
+        String rankingKey = "";
+        LocalDate today = LocalDate.now();
+
+        switch (period1){
+            case DAILY:
+                rankingKey = RANKING_KEY + today.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+                break;
+            case WEEKLY:
+                WeekFields weekFields = WeekFields.of(Locale.getDefault());
+                int weekNumber = today.get(weekFields.weekOfWeekBasedYear());
+                int year = today.get(weekFields.weekBasedYear());
+                rankingKey = RANKING_KEY + String.format("%d-%02d", year, weekNumber);
+                break;
+            case MONTHLY:
+                YearMonth yearMonth = YearMonth.from(today);
+                rankingKey = RANKING_KEY + yearMonth.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+                break;
+            default:
+                rankingKey = DEFAULT_RANKING;
+                break;
+        }
+        return rankingKey;
+    }
+
+    enum Period{
+        DAILY,
+        WEEKLY,
+        MONTHLY
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
@@ -20,11 +20,11 @@ public class RankingController implements RankingV1ApiSpec{
 
     @Override
     @GetMapping(value = "/api/v1/rankings", consumes = "applciation/json")
-    public ApiResponse<?> get(@RequestParam("date") LocalDate today,
+    public ApiResponse<?> get(@RequestParam("date") LocalDate date,
                               @RequestParam("period") String period,
                              @RequestParam("size") int size,
                              @RequestParam("page") int page) {
-        Page<ProductInfo.DataList> result = rankingFacade.getProductRanking(today, period, size, page);
+        Page<ProductInfo.DataList> result = rankingFacade.getProductRanking(date, period, size, page);
         return ApiResponse.success(result);
 //        return ApiResponse.success(result.stream().map(RankV1Dto.Summary::from)
 //                .collect(Collectors.toList()));

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
@@ -21,9 +21,10 @@ public class RankingController implements RankingV1ApiSpec{
     @Override
     @GetMapping(value = "/api/v1/rankings", consumes = "applciation/json")
     public ApiResponse<?> get(@RequestParam("date") LocalDate today,
-                                                         @RequestParam("size") int size,
-                                                         @RequestParam("page") int page) {
-        Page<ProductInfo.DataList> result = rankingFacade.getProductRanking(today, size, page);
+                              @RequestParam("period") String period,
+                             @RequestParam("size") int size,
+                             @RequestParam("page") int page) {
+        Page<ProductInfo.DataList> result = rankingFacade.getProductRanking(today, period, size, page);
         return ApiResponse.success(result);
 //        return ApiResponse.success(result.stream().map(RankV1Dto.Summary::from)
 //                .collect(Collectors.toList()));

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -16,7 +16,7 @@ public interface RankingV1ApiSpec {
     )
     ApiResponse<?> get(
             @Schema(name = "오늘 날짜", description = "조회할 오늘 랭킹 날짜")
-            LocalDate today,
+            LocalDate date,
             @Schema(name = "날짜 옵션", description = "일간/주간/월간")
             String period,
             @Schema(name = "Page Size", description = "조회 Page Size")

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -17,6 +17,8 @@ public interface RankingV1ApiSpec {
     ApiResponse<?> get(
             @Schema(name = "오늘 날짜", description = "조회할 오늘 랭킹 날짜")
             LocalDate today,
+            @Schema(name = "날짜 옵션", description = "일간/주간/월간")
+            String period,
             @Schema(name = "Page Size", description = "조회 Page Size")
             int size,
             @Schema(name = "Page Num", description = "Page 번호")

--- a/apps/ranking-batch/build.gradle.kts
+++ b/apps/ranking-batch/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    id("java")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:rediss"))
+    implementation(project(":supports:jackson"))
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+    implementation("org.springframework.batch:spring-batch-test")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+//    testImplementation(testFixtures(project(":modules:rediss")))
+
+//    testImplementation(platform("org.junit:junit-bom:5.10.0"))
+//    testImplementation("org.junit.jupiter:junit-jupiter")
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/RankingBatchApplication.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/RankingBatchApplication.java
@@ -1,0 +1,16 @@
+package com.loopers;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@EnableBatchProcessing
+@SpringBootApplication
+public class RankingBatchApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(RankingBatchApplication.class, args);
+    }
+
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/application/RankingScheduler.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/application/RankingScheduler.java
@@ -1,0 +1,39 @@
+package com.loopers.application;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingScheduler {
+    private final JobLauncher jobLauncher;
+    private final Job rankingJob;
+
+    @Scheduled(cron = "0 0 1 * * ?")
+    public void rankingJob(){
+        try {
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("targetDate",
+                                LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("yyyyMMdd")))
+                    .toJobParameters();
+
+            JobExecution jobExecution = jobLauncher.run(rankingJob, jobParameters);
+            log.info("{} Job 실행 : {}", jobExecution.getJobInstance().getJobName(), jobExecution.getStatus());
+        } catch (JobExecutionAlreadyRunningException | JobRestartException |
+                 JobInstanceAlreadyCompleteException | JobParametersInvalidException e){
+            log.error("배치 Job Exception." , e);
+        }
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/RankingJobConfig.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/RankingJobConfig.java
@@ -1,7 +1,7 @@
 package com.loopers.batch.job;
 
 
-import jakarta.persistence.EntityManagerFactory;
+import com.loopers.batch.listener.JobParameterSetupListener;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 public class RankingJobConfig {
     private final JobRepository jobRepository;
-    private final EntityManagerFactory entityManagerFactory;
+    private JobParameterSetupListener jobParameterSetupListener;
     private static final double ALPHA = 0.5; // 지수가중평균 가중치
 
     @Bean
@@ -28,6 +28,7 @@ public class RankingJobConfig {
     ) {
         return new JobBuilder("rankingJob", jobRepository)
                 .incrementer(new RunIdIncrementer())
+                .listener(jobParameterSetupListener)
                 .start(dailyRankingStep)
                 .next(weeklyScoreCalculateStep)
                 .next(weeklyRankingStep)

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/RankingJobConfig.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/RankingJobConfig.java
@@ -1,0 +1,39 @@
+package com.loopers.batch.job;
+
+
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class RankingJobConfig {
+    private final JobRepository jobRepository;
+    private final EntityManagerFactory entityManagerFactory;
+    private static final double ALPHA = 0.5; // 지수가중평균 가중치
+
+    @Bean
+    public Job rankingJob(
+            Step dailyRankingStep,
+            Step weeklyScoreCalculateStep,
+            Step weeklyRankingStep,
+            Step monthlyScoreCalculateStep,
+            Step monthlyRankingStep
+    ) {
+        return new JobBuilder("rankingJob", jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(dailyRankingStep)
+                .next(weeklyScoreCalculateStep)
+                .next(weeklyRankingStep)
+                .next(monthlyScoreCalculateStep)
+                .next(monthlyRankingStep)
+                .build();
+    }
+
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/listener/JobParameterSetupListener.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/listener/JobParameterSetupListener.java
@@ -1,0 +1,48 @@
+package com.loopers.batch.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
+@Slf4j
+@Component
+public class JobParameterSetupListener implements JobExecutionListener {
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+        String targetDate = jobExecution.getJobParameters().getString("targetDate");
+
+        String targetWeek = getWeek(targetDate);
+        String targetMonth = getMonth(targetDate);
+
+        jobExecution.getExecutionContext().put("targetWeek", targetWeek);
+        jobExecution.getExecutionContext().put("targetMonth", targetMonth);
+
+        log.info("===========================");
+        log.info("배치 Parameter Setting.");
+        log.info("targetDate = {}", targetDate);
+        log.info("targetWeek = {}", targetWeek);
+        log.info("targetMonth = {}", targetMonth);
+        log.info("===========================");
+    }
+
+    private String getWeek(String targetDate){
+        LocalDate date = LocalDate.parse(targetDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+        WeekFields weekFields = WeekFields.of(Locale.getDefault());
+        int weekNumber = date.get(weekFields.weekOfWeekBasedYear());
+        int year = date.get(weekFields.weekBasedYear());
+        return String.format("%d-%02d", year, weekNumber);
+    }
+
+    private String getMonth(String targetDate){
+        LocalDate date = LocalDate.parse(targetDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+        YearMonth yearMonth = YearMonth.from(date);
+        return yearMonth.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/step/DailyRankingStepConfig.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/step/DailyRankingStepConfig.java
@@ -1,0 +1,66 @@
+package com.loopers.batch.step;
+
+import com.loopers.batch.step.reader.CustomRedisItemReader;
+import com.loopers.config.redis.RedisCacheWrapper;
+import com.loopers.domain.ranking.DailyRanking;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class DailyRankingStepConfig {
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    @Bean
+    public Step dailyRankingStep(ItemReader<DailyRanking> dailyReader,
+                                 ItemWriter<DailyRanking> dailyWriter) {
+        return new StepBuilder("dailyRankingStep", jobRepository)
+                .<DailyRanking, DailyRanking>chunk(1000, transactionManager)
+                .reader(dailyReader)
+                .writer(dailyWriter)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public CustomRedisItemReader<DailyRanking> dailyReader(@Value("#{jobParameters[targetDate]}") String targetDateStr,
+                                                           RedisCacheWrapper redisCache,
+                                                           @Value("#{stepExecutionContext['chunkSize'] ?: 1000}")  int chunkSize) {
+        return new CustomRedisItemReader<DailyRanking>(redisCache, targetDateStr, chunkSize);
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<DailyRanking> dailyWriter(
+            NamedParameterJdbcTemplate jdbcTemplate
+    ) {
+        final String INSERT_SQL =
+                "INSERT INTO mv_daily_ranking (period, product_id, rank, score) VALUES (:period, :productId, :rank, :score)";
+
+        return new JdbcBatchItemWriterBuilder<DailyRanking>()
+                .namedParametersJdbcTemplate(jdbcTemplate)
+                .sql(INSERT_SQL)
+                .itemSqlParameterSourceProvider(item -> {
+                    MapSqlParameterSource source = new MapSqlParameterSource();
+                    source.addValue("productId", item.getId().getProductId());
+                    source.addValue("period", item.getId().getPeriod());
+                    source.addValue("score", item.getScore());
+                    source.addValue("rank", item.getRank());
+                    return source;
+                })
+                .build();
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/step/MonthlyRankingStepConfig.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/step/MonthlyRankingStepConfig.java
@@ -1,0 +1,66 @@
+package com.loopers.batch.step;
+
+import com.loopers.batch.step.writer.CustomRedisItemWriter;
+import com.loopers.config.redis.RedisCacheWrapper;
+import com.loopers.domain.ranking.MonthlyRanking;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class MonthlyRankingStepConfig {
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final RedisCacheWrapper redisCacheWrapper;
+    private final StepExecution stepExecution;
+
+    @Bean
+    public Step MonthlyRankingStep(ItemReader<MonthlyRanking> monthlyReader,
+                                            ItemWriter<MonthlyRanking> monthlyWriter) {
+        return new StepBuilder("monthlyRankingStep", jobRepository)
+                .<MonthlyRanking, MonthlyRanking>chunk(1000, transactionManager)
+                .reader(monthlyReader)
+                .writer(monthlyWriter)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<MonthlyRanking> monthlyReader(
+                                                          EntityManagerFactory entityManagerFactory) {
+
+        String targetWeek = stepExecution.getJobExecution().getExecutionContext().getString("targetMonth");
+        Map<String, Object> params = new HashMap<>();
+        params.put("metricDate", targetWeek);
+
+        return new JpaPagingItemReaderBuilder<MonthlyRanking>()
+                .name("monthlyRankingReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT d FROM MonthlyRanking d WHERE d.metricDate = :metricDate order by score")
+                .parameterValues(params)
+                .pageSize(1000)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public CustomRedisItemWriter<MonthlyRanking> monthlyWriter() {
+        String targetMonth = stepExecution.getJobExecution().getExecutionContext().getString("targetMonth");
+        return new CustomRedisItemWriter<MonthlyRanking>(redisCacheWrapper, targetMonth);
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/step/MonthlyScoreCalculateStepConfig.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/step/MonthlyScoreCalculateStepConfig.java
@@ -29,7 +29,6 @@ import java.util.Map;
 public class MonthlyScoreCalculateStepConfig {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
-    private final EntityManagerFactory entityManagerFactory;
     private final MonthlyScoreCalculateProcessor processor;
 
     @Bean

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/step/MonthlyScoreCalculateStepConfig.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/step/MonthlyScoreCalculateStepConfig.java
@@ -1,0 +1,91 @@
+package com.loopers.batch.step;
+
+import com.loopers.batch.step.processor.MonthlyScoreCalculateProcessor;
+import com.loopers.domain.ranking.DailyRanking;
+import com.loopers.domain.ranking.MonthlyRanking;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class MonthlyScoreCalculateStepConfig {
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final EntityManagerFactory entityManagerFactory;
+    private final MonthlyScoreCalculateProcessor processor;
+
+    @Bean
+    public Step MonthlyScoreCalculateStep(ItemReader<DailyRanking> monthlyScoreReader,
+                                 ItemWriter<MonthlyRanking> monthlyScoreWriter) {
+        return new StepBuilder("monthlyScoreCalculateStep", jobRepository)
+                .<DailyRanking, MonthlyRanking>chunk(1000, transactionManager)
+                .reader(monthlyScoreReader)
+                .processor(processor)
+                .writer(monthlyScoreWriter)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<DailyRanking> monthlyScoreReader(@Value("#{jobParameters[targetDate]}") String targetDateStr,
+                                                         EntityManagerFactory entityManagerFactory) {
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("metricDate", targetDateStr);
+
+        return new JpaPagingItemReaderBuilder<DailyRanking>()
+                .name("dailyRankingReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT d FROM DailyRanking d WHERE d.metricDate = :metricDate order by rank")
+                .parameterValues(params)
+                .pageSize(1000)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<MonthlyRanking> monthlyScoreWriter(
+            NamedParameterJdbcTemplate jdbcTemplate
+    ) {
+        final String INSERT_SQL =
+                "INSERT INTO mv_monthly_ranking (period, product_id, score) VALUES (:period, :productId, :score)";
+
+        return new JdbcBatchItemWriterBuilder<MonthlyRanking>()
+                .namedParametersJdbcTemplate(jdbcTemplate)
+                .sql(INSERT_SQL)
+                .itemSqlParameterSourceProvider(item -> {
+                    MapSqlParameterSource source = new MapSqlParameterSource();
+                    source.addValue("productId", item.getId().getProductId());
+                    source.addValue("period", item.getId().getPeriod());
+                    source.addValue("score", item.getScore());
+                    return source;
+                })
+                .build();
+    }
+
+//    @Bean
+//    @StepScope
+//    public JpaItemWriter<MonthlyRanking> monthlyScoreWriter() {
+//        JpaItemWriter<MonthlyRanking> writer = new JpaItemWriter<>();
+//        writer.setEntityManagerFactory(entityManagerFactory);
+//        return writer;
+//    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/step/WeeklyRankingStepConfig.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/step/WeeklyRankingStepConfig.java
@@ -1,0 +1,66 @@
+package com.loopers.batch.step;
+
+import com.loopers.batch.step.writer.CustomRedisItemWriter;
+import com.loopers.config.redis.RedisCacheWrapper;
+import com.loopers.domain.ranking.WeeklyRanking;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class WeeklyRankingStepConfig {
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final RedisCacheWrapper redisCacheWrapper;
+    private final StepExecution stepExecution;
+
+    @Bean
+    public Step WeeklyRankingStep(ItemReader<WeeklyRanking> weeklyReader,
+                                            ItemWriter<WeeklyRanking> weeklyWriter) {
+        return new StepBuilder("weeklyRankingStep", jobRepository)
+                .<WeeklyRanking, WeeklyRanking>chunk(1000, transactionManager)
+                .reader(weeklyReader)
+                .writer(weeklyWriter)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<WeeklyRanking> weeklyReader(
+                                                          EntityManagerFactory entityManagerFactory) {
+
+        String targetWeek = stepExecution.getJobExecution().getExecutionContext().getString("targetWeek");
+        Map<String, Object> params = new HashMap<>();
+        params.put("metricDate", targetWeek);
+
+        return new JpaPagingItemReaderBuilder<WeeklyRanking>()
+                .name("weeklyRankingReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT d FROM WeeklyRanking d WHERE d.metricDate = :metricDate order by score")
+                .parameterValues(params)
+                .pageSize(1000)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public CustomRedisItemWriter<WeeklyRanking> weeklyWriter() {
+        String targetWeek = stepExecution.getJobExecution().getExecutionContext().getString("targetWeek");
+        return new CustomRedisItemWriter<WeeklyRanking>(redisCacheWrapper, targetWeek);
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/step/WeeklyScoreCalculateStepConfig.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/step/WeeklyScoreCalculateStepConfig.java
@@ -1,0 +1,93 @@
+package com.loopers.batch.step;
+
+import com.loopers.batch.step.processor.WeeklyScoreCalculateProcessor;
+import com.loopers.domain.ranking.DailyRanking;
+import com.loopers.domain.ranking.WeeklyRanking;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class WeeklyScoreCalculateStepConfig {
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final EntityManagerFactory entityManagerFactory;
+    private final WeeklyScoreCalculateProcessor processor;
+
+    @Bean
+    public Step WeeklyScoreCalculateStep(ItemReader<DailyRanking> weeklyScoreReader,
+                                 ItemWriter<WeeklyRanking> weeklyScoreWriter) {
+        return new StepBuilder("weeklyRankingTempStep", jobRepository)
+                .<DailyRanking, WeeklyRanking>chunk(1000, transactionManager)
+                .reader(weeklyScoreReader)
+                .processor(processor)
+                .writer(weeklyScoreWriter)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<DailyRanking> weeklyScoreReader(@Value("#{jobParameters[targetDate]}") String targetDateStr,
+                                                         @Value("#{stepExecutionContext['chunkSize'] ?: 1000}")  int chunkSize,
+                                                         EntityManagerFactory entityManagerFactory) {
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("metricDate", targetDateStr);
+
+        return new JpaPagingItemReaderBuilder<DailyRanking>()
+                .name("dailyRankingReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT d FROM DailyRanking d WHERE d.metricDate = :metricDate order by rank")
+                .parameterValues(params)
+                .pageSize(1000)
+                .build();
+    }
+
+
+    @Bean
+    @StepScope
+    public ItemWriter<WeeklyRanking> weeklyScoreWriter(
+            NamedParameterJdbcTemplate jdbcTemplate
+    ) {
+        final String INSERT_SQL =
+                "INSERT INTO mv_weekly_ranking (period, product_id, score) VALUES (:period, :productId, :score)";
+
+        return new JdbcBatchItemWriterBuilder<WeeklyRanking>()
+                .namedParametersJdbcTemplate(jdbcTemplate)
+                .sql(INSERT_SQL)
+                .itemSqlParameterSourceProvider(item -> {
+                    MapSqlParameterSource source = new MapSqlParameterSource();
+                    source.addValue("productId", item.getId().getProductId());
+                    source.addValue("period", item.getId().getPeriod());
+                    source.addValue("score", item.getScore());
+                    return source;
+                })
+                .build();
+    }
+
+//    @Bean
+//    @StepScope
+//    public JpaItemWriter<WeeklyRanking> weeklyScoreWriter() {
+//        JpaItemWriter<WeeklyRanking> writer = new JpaItemWriter<>();
+//        writer.setEntityManagerFactory(entityManagerFactory);
+//        return writer;
+//    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/step/processor/MonthlyScoreCalculateProcessor.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/step/processor/MonthlyScoreCalculateProcessor.java
@@ -5,6 +5,7 @@ import com.loopers.domain.ranking.MonthlyRanking;
 import com.loopers.domain.ranking.MonthlyRankingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 
@@ -18,11 +19,13 @@ import java.util.Optional;
 @Slf4j
 public class MonthlyScoreCalculateProcessor implements ItemProcessor<DailyRanking, MonthlyRanking> {
     private final MonthlyRankingRepository monthlyRankingRepository;
+    private final StepExecution stepExecution;
     private static final double ALPHA = 0.5; // 지수가중평균 가중치
 
     @Override
     public MonthlyRanking process(DailyRanking dailyRanking) {
-        String monthlyPeriod = getMonthlyPeriod(dailyRanking.getId().getPeriod());
+        String monthlyPeriod = stepExecution.getJobExecution().getExecutionContext().getString("targetMonth");
+//        String monthlyPeriod = getMonthlyPeriod(dailyRanking.getId().getPeriod());
 
         Optional<MonthlyRanking> existingMonthlyRanking = monthlyRankingRepository.findByProductIdAndPeriod(
                 dailyRanking.getId().getProductId(), monthlyPeriod);

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/step/processor/MonthlyScoreCalculateProcessor.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/step/processor/MonthlyScoreCalculateProcessor.java
@@ -1,0 +1,54 @@
+package com.loopers.batch.step.processor;
+
+import com.loopers.domain.ranking.DailyRanking;
+import com.loopers.domain.ranking.MonthlyRanking;
+import com.loopers.domain.ranking.MonthlyRankingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MonthlyScoreCalculateProcessor implements ItemProcessor<DailyRanking, MonthlyRanking> {
+    private final MonthlyRankingRepository monthlyRankingRepository;
+    private static final double ALPHA = 0.5; // 지수가중평균 가중치
+
+    @Override
+    public MonthlyRanking process(DailyRanking dailyRanking) {
+        String monthlyPeriod = getMonthlyPeriod(dailyRanking.getId().getPeriod());
+
+        Optional<MonthlyRanking> existingMonthlyRanking = monthlyRankingRepository.findByProductIdAndPeriod(
+                dailyRanking.getId().getProductId(), monthlyPeriod);
+
+        double newScore = dailyRanking.getScore();
+        if (existingMonthlyRanking.isPresent()) {
+            MonthlyRanking monthlyRanking = existingMonthlyRanking.get();
+            double oldScore = monthlyRanking.getScore();
+            newScore = (ALPHA * newScore) + ((1 - ALPHA) * oldScore);
+            monthlyRanking.setScore(newScore);
+
+            log.info("Updating existing WeeklyRanking for productId: {} with new score: {}", dailyRanking.getId().getProductId(), newScore);
+            return monthlyRanking;
+        } else {
+            MonthlyRanking newMonthlyRanking = MonthlyRanking.of(
+                    monthlyPeriod, dailyRanking.getId().getProductId(), newScore
+            );
+            log.info("Creating new WeeklyRanking for productId: {} with score: {}", dailyRanking.getId().getProductId(), newScore);
+            return newMonthlyRanking;
+        }
+    }
+
+    private String getMonthlyPeriod(String dateStr) {
+        LocalDate date = LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyyMMdd"));
+        YearMonth yearMonth = YearMonth.from(date);
+        return yearMonth.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+    }
+
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/step/processor/WeeklyScoreCalculateProcessor.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/step/processor/WeeklyScoreCalculateProcessor.java
@@ -1,0 +1,56 @@
+package com.loopers.batch.step.processor;
+
+import com.loopers.domain.ranking.DailyRanking;
+import com.loopers.domain.ranking.WeeklyRanking;
+import com.loopers.domain.ranking.WeeklyRankingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WeeklyScoreCalculateProcessor implements ItemProcessor<DailyRanking, WeeklyRanking> {
+    private final WeeklyRankingRepository weeklyRankingRepository;
+    private static final double ALPHA = 0.5; // 지수가중평균 가중치
+
+    @Override
+    public WeeklyRanking process(DailyRanking dailyRanking) {
+        String weeklyPeriod = getWeeklyPeriod(dailyRanking.getId().getPeriod());
+
+        Optional<WeeklyRanking> existingWeeklyRanking = weeklyRankingRepository.findByProductIdAndPeriod(
+                dailyRanking.getId().getProductId(), weeklyPeriod);
+
+        double newScore = dailyRanking.getScore();
+        if (existingWeeklyRanking.isPresent()) {
+            WeeklyRanking weeklyRanking = existingWeeklyRanking.get();
+            double oldScore = weeklyRanking.getScore();
+            newScore = (ALPHA * newScore) + ((1 - ALPHA) * oldScore);
+            weeklyRanking.setScore(newScore);
+
+            log.info("Updating existing WeeklyRanking for productId: {} with new score: {}", dailyRanking.getId().getProductId(), newScore);
+            return weeklyRanking;
+        } else {
+            WeeklyRanking newWeeklyRanking = WeeklyRanking.of(
+                    weeklyPeriod, dailyRanking.getId().getProductId(), newScore
+            );
+            log.info("Creating new WeeklyRanking for productId: {} with score: {}", dailyRanking.getId().getProductId(), newScore);
+            return newWeeklyRanking;
+        }
+    }
+
+    private String getWeeklyPeriod(String dateStr) {
+        LocalDate date = LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyyMMdd"));
+        WeekFields weekFields = WeekFields.of(Locale.getDefault());
+        int weekNumber = date.get(weekFields.weekOfWeekBasedYear());
+        int year = date.get(weekFields.weekBasedYear());
+        return String.format("%d-%02d", year, weekNumber);
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/step/processor/WeeklyScoreCalculateProcessor.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/step/processor/WeeklyScoreCalculateProcessor.java
@@ -5,6 +5,7 @@ import com.loopers.domain.ranking.WeeklyRanking;
 import com.loopers.domain.ranking.WeeklyRankingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 
@@ -19,11 +20,13 @@ import java.util.Optional;
 @Slf4j
 public class WeeklyScoreCalculateProcessor implements ItemProcessor<DailyRanking, WeeklyRanking> {
     private final WeeklyRankingRepository weeklyRankingRepository;
+    private final StepExecution stepExecution;
     private static final double ALPHA = 0.5; // 지수가중평균 가중치
 
     @Override
     public WeeklyRanking process(DailyRanking dailyRanking) {
-        String weeklyPeriod = getWeeklyPeriod(dailyRanking.getId().getPeriod());
+        String weeklyPeriod = stepExecution.getJobExecution().getExecutionContext().getString("targetWeek");
+//        String weeklyPeriod = getWeeklyPeriod(dailyRanking.getId().getPeriod());
 
         Optional<WeeklyRanking> existingWeeklyRanking = weeklyRankingRepository.findByProductIdAndPeriod(
                 dailyRanking.getId().getProductId(), weeklyPeriod);

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/step/reader/CustomRedisItemReader.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/step/reader/CustomRedisItemReader.java
@@ -1,0 +1,74 @@
+package com.loopers.batch.step.reader;
+
+import com.loopers.config.redis.RedisCacheWrapper;
+import com.loopers.domain.ranking.DailyRanking;
+import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class CustomRedisItemReader<T> extends AbstractItemCountingItemStreamItemReader {
+    private final RedisCacheWrapper redisCacheWrapper;
+    private final String targetDateStr;
+    private final String key;
+    private final int chunkSize;
+    private final String RANKING_KEY = "ranking:product:";
+
+    private Iterator<T> dataIterator;
+
+    public CustomRedisItemReader(RedisCacheWrapper redisCacheWrapper, String targetDateStr,int chunkSize) {
+        this.redisCacheWrapper = redisCacheWrapper;
+        this.targetDateStr = targetDateStr;
+        this.chunkSize = chunkSize;
+        this.key = RANKING_KEY + targetDateStr;
+    }
+
+    @Override
+    protected void doOpen() throws Exception {
+        Assert.notNull(redisCacheWrapper, "RedisTemplate must not be null");
+        Assert.notNull(key, "Key must not be null");
+
+        Long totalItems = redisCacheWrapper.count(key);
+        if (totalItems == null || totalItems == 0) {
+            this.dataIterator = null;
+        }
+    }
+
+    @Override
+    protected T doRead() throws Exception {
+        if (dataIterator == null || !dataIterator.hasNext()) {
+            // 다음 청크를 읽어오기 위한 offset 계산 -> DB 에 있는 Read_Count 를 가져옴.
+            int offset = getCurrentItemCount();
+
+            // ZSET에서 지정된 범위의 데이터를 가져옴
+            Map<Long, Float> dataSet = redisCacheWrapper.getRangeWithScore(key, offset, offset + chunkSize - 1);
+
+            if (dataSet == null || dataSet.isEmpty()) {
+                return null; // 더 이상 읽을 데이터가 없으면 null 반환
+            }
+
+            // Redis에서 가져온 데이터를 랭킹과 함께 가공
+            List<DailyRanking> rankingDataList = new ArrayList<>();
+            int rank = offset + 1; // 랭킹은 1부터 시작하므로 +1
+            for (Map.Entry<Long, Float> data : dataSet.entrySet()) {
+                Long productId = data.getKey();
+                Double score = data.getValue().doubleValue();
+                rankingDataList.add(DailyRanking.of(targetDateStr, productId, rank, score));
+                rank++;
+            }
+
+            this.dataIterator = (Iterator<T>) rankingDataList.iterator();
+//            this.dataIterator = (Iterator<T>) dataSet.entrySet().iterator();
+        }
+
+        return dataIterator.next();
+    }
+
+    @Override
+    protected void doClose() throws Exception {
+        this.dataIterator = null;
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/step/writer/CustomRedisItemWriter.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/step/writer/CustomRedisItemWriter.java
@@ -1,0 +1,37 @@
+package com.loopers.batch.step.writer;
+
+import com.loopers.config.redis.RedisCacheWrapper;
+import com.loopers.domain.ranking.Ranking;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.support.AbstractItemStreamItemWriter;
+import org.springframework.data.redis.core.DefaultTypedTuple;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+public class CustomRedisItemWriter<T> extends AbstractItemStreamItemWriter {
+    private final RedisCacheWrapper redisCacheWrapper;
+    private final String key;
+    private final String RANKING_KEY = "ranking:product:";
+
+    private Iterator<T> dataIterator;
+
+    public CustomRedisItemWriter(RedisCacheWrapper redisCacheWrapper, String targetDateStr) {
+        this.redisCacheWrapper = redisCacheWrapper;
+        this.key = RANKING_KEY + targetDateStr;
+    }
+
+    @Override
+    public void write(Chunk chunk) throws Exception {
+        Set<ZSetOperations.TypedTuple<String>> tuples = new HashSet<>();
+        for (Object item : chunk.getItems()) {
+            Ranking ranking = (Ranking) item;
+            DefaultTypedTuple<String> tuple = new DefaultTypedTuple<>(
+                    ranking.getProductId().toString(), ranking.getScore());
+            tuples.add(tuple);
+        }
+        redisCacheWrapper.addZset(key, tuples);
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/domain/metric/ProductMetric.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/domain/metric/ProductMetric.java
@@ -1,0 +1,45 @@
+package com.loopers.domain.metric;
+
+import com.loopers.domain.BaseAuditableEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "product_metrics")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ProductMetric extends BaseAuditableEntity {
+    @EmbeddedId
+    private MetricId id;
+
+    @Column(name = "view_count")
+    private Long viewCount;
+
+    @Column(name = "like_count")
+    private Long likeCount;
+
+    @Column(name = "sales_volume")
+    private Long salesVolume;
+
+    @Embeddable
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    @EqualsAndHashCode
+    public static class MetricId {
+        @Column(name = "product_id", nullable = false, unique = true)
+        private Long productId;
+
+        @Column(name = "aggregation_date")
+        private LocalDate aggregationDate;
+
+        private MetricId(Long productId, LocalDate aggregationDate){
+            this.productId = productId;
+            this.aggregationDate = aggregationDate;
+        }
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/domain/ranking/DailyRanking.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/domain/ranking/DailyRanking.java
@@ -1,0 +1,52 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "mv_daily_ranking")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@Getter
+public class DailyRanking {
+    @EmbeddedId
+    private DailyId id;
+
+    @Column(nullable = false)
+    private int rank;
+    @Column(nullable = false)
+    private Double Score;
+
+    private DailyRanking(DailyId id, int rank, Double score) {
+        this.id = id;
+        this.rank = rank;
+        Score = score;
+    }
+
+    public static DailyRanking of(String period, Long productId, int rank, Double score) {
+        return new DailyRanking(DailyId.of(period, productId), rank, score);
+    }
+
+    @Embeddable
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    @EqualsAndHashCode
+    public static class DailyId{
+
+        @Column(nullable = false)
+        private String period;
+
+        @Column(nullable = false)
+        private Long productId;
+
+        private DailyId(String period, Long productId) {
+            this.period = period;
+            this.productId = productId;
+        }
+
+        public static DailyId of(String period, Long productId){
+            return new DailyId(period, productId);
+        }
+
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/domain/ranking/MonthlyRanking.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/domain/ranking/MonthlyRanking.java
@@ -1,0 +1,62 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.BaseAuditableEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Table(name = "mv_monthly_ranking")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@Getter
+public class MonthlyRanking extends BaseAuditableEntity implements Ranking {
+    @EmbeddedId
+    private MonthlyId id;
+
+    @Setter
+    @Column(nullable = false)
+    private Double score;
+
+
+    private MonthlyRanking(MonthlyId id, Double score) {
+        this.id = id;
+        this.score = score;
+    }
+
+    public static MonthlyRanking of(String period, Long productId, Double score) {
+        return new MonthlyRanking(
+                MonthlyId.of(period, productId),
+                score
+        );
+    }
+
+    @Override
+    public Long getProductId() {
+        return this.id.productId;
+    }
+
+
+    @Embeddable
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    @EqualsAndHashCode
+    public static class MonthlyId{
+
+        @Column(nullable = false)
+        private String period;
+
+        @Column(nullable = false)
+        private Long productId;
+
+        private MonthlyId(String period, Long productId) {
+            this.period = period;
+            this.productId = productId;
+        }
+
+        public static MonthlyId of(String period, Long productId) {
+            return new MonthlyId(period, productId);
+        }
+    }
+
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/domain/ranking/MonthlyRankingRepository.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/domain/ranking/MonthlyRankingRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.ranking;
+
+import java.util.Optional;
+
+public interface MonthlyRankingRepository {
+    Optional<MonthlyRanking> findByProductIdAndPeriod(Long productId, String period);
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/domain/ranking/Ranking.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/domain/ranking/Ranking.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.ranking;
+
+public interface Ranking {
+    public Long getProductId();
+    public Double getScore();
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/domain/ranking/WeeklyRanking.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/domain/ranking/WeeklyRanking.java
@@ -1,0 +1,63 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.BaseAuditableEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "mv_weekly_ranking")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@Getter
+public class WeeklyRanking extends BaseAuditableEntity implements Ranking {
+    @EmbeddedId
+    private WeeklyId id;
+
+//    @Setter
+//    @Column(nullable = false)
+//    private int rank;
+
+    @Setter
+    @Column(nullable = false)
+    private Double score;
+
+    private WeeklyRanking(WeeklyId id, Double score) {
+        this.id = id;
+        this.score = score;
+    }
+
+    public static WeeklyRanking of(String period, Long productId, Double score) {
+        return new WeeklyRanking(
+                WeeklyId.of(period, productId),
+                score
+        );
+    }
+
+    @Override
+    public Long getProductId() {
+        return this.id.productId;
+    }
+
+    @Embeddable
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    @EqualsAndHashCode
+    public static class WeeklyId{
+
+        @Column(nullable = false)
+        private String period;
+
+        @Column(nullable = false)
+        private Long productId;
+
+        private WeeklyId(String period, Long productId) {
+            this.period = period;
+            this.productId = productId;
+        }
+
+        public static WeeklyId of(String period, Long productId) {
+            return new WeeklyId(period, productId);
+        }
+    }
+
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/domain/ranking/WeeklyRankingRepository.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/domain/ranking/WeeklyRankingRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.ranking;
+
+import java.util.Optional;
+
+public interface WeeklyRankingRepository {
+
+    Optional<WeeklyRanking> findByProductIdAndPeriod(Long productId, String period);
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/infrastructure/metric/ProductMetricRepository.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/infrastructure/metric/ProductMetricRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.metric;
+
+import com.loopers.domain.metric.ProductMetric;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductMetricRepository extends JpaRepository<ProductMetric, ProductMetric.MetricId> {
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingJpaRepository.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MonthlyRanking;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MonthlyRankingJpaRepository extends JpaRepository<MonthlyRanking, MonthlyRanking.MonthlyId> {
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingRepositoryImpl.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MonthlyRanking;
+import com.loopers.domain.ranking.MonthlyRankingRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class MonthlyRankingRepositoryImpl implements MonthlyRankingRepository {
+    private final MonthlyRankingJpaRepository jpaRepository;
+
+    public MonthlyRankingRepositoryImpl(MonthlyRankingJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<MonthlyRanking> findByProductIdAndPeriod(Long productId, String period) {
+        return jpaRepository.findById(MonthlyRanking.MonthlyId.of(period, productId));
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingJpaRepository.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.WeeklyRanking;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WeeklyRankingJpaRepository extends JpaRepository<WeeklyRanking, WeeklyRanking.WeeklyId> {
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingRepositoryImpl.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.WeeklyRanking;
+import com.loopers.domain.ranking.WeeklyRankingRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class WeeklyRankingRepositoryImpl implements WeeklyRankingRepository {
+    private final WeeklyRankingJpaRepository jpaRepository;
+
+    public WeeklyRankingRepositoryImpl(WeeklyRankingJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<WeeklyRanking> findByProductIdAndPeriod(Long productId, String period) {
+        return jpaRepository.findById(WeeklyRanking.WeeklyId.of(period, productId));
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,7 @@ include(
     ":supports:logging",
     ":supports:monitoring",
     "apps:commerce-streamer",
+    "apps:ranking-batch",
     "modules:kafka",
     "modules:event:core",
     "modules:event:producer"
@@ -34,3 +35,5 @@ pluginManagement {
         }
     }
 }
+
+include("apps:ranking-batch")


### PR DESCRIPTION
## 📌 Summary
주간/월간 랭킹 추가

라이팅 과제 제출을 못해서 멘토님들에게 말을 전할 기회가 없을 거 같아 PR 에 적습니다.
10주동안 너무 감사했습니다! 현업이 있으시니 많이 바쁘셨을텐데도 신경써주시고 잘 답해주셔서 얻어간 게 많은 거 같습니다.
제가 좀 더 아는게 있었더라면 더 많이 질문하고 했을텐데 제 실력에 아쉬운 점이 너무 많았지만.. 그래도 계속 격려해주셔서 10주간 올 수 있었던거 같습니다.
앨런 코치님! 이직하시면서 많이 바쁘셨을텐데도 항상 잘 챙겨주셔서 감사했습니다. 멘토링 때도 가장 쉽게 설명해주셔서 너무 좋았습니다!
10주간 너무 고생하셨습니다~!!

## 💬 Review Points
### 1. 주간/월간 랭킹 계산 프로세스
   : 일단위 배치를 실행하여 일단위 Score 값을 누계합니다.
     DailyRanking 을 Redis 에서 조회 후 DB 에 적재 (Score 까지) -> DailyRanking 을 조회 후, 주간/월간 테이블에 누계 -> Score 를 기반으로 order by 하여 Redis ZSET 에 저장 -> Redis 에서 Ranking 생성

- 위와 같은 프로세스로 실제 Ranking 의 계산은 Redis 에서 계산되도록 했습니다.
- 일단위 누계 시, Chunk 기반 처리 시 모든 일 데이터가 적재되기 전까지는 실제 랭킹을 계산할 수 없다고 판단했습니다.
- 그 경우 아직 Ranking 이 계산되지 않고 Score 만 누계된 데이터가 조회될 수도 있는 Risk 가 존재하기 때문에 [Score 계산 / Ranking 계산] 용 테이블을 별도로 나누어야 겠다는 생각이 들었습니다.
- **이 경우, 일단위 랭킹이 이미 Redis 에서 서비스 중이고, 동일API 를 이용해 주간/월간 랭킹도 서비스하는 경우, 동일하게 Redis 에서 서비스하는게 낫겠다는 판단으로 mv 에는 Score 까지만 계산하고 실제 랭킹은 Redis 에서 계산되도록 변경하였습니다.**
- **[Score 계산 / Ranking 계산] 용 테이블이 별도로 생성되어야 한다는 판단이 맞을까요?**

### 2. Spring Batch Processor
- 기본적으로 Read 를 Chunk 단위로 하더라도 Processor 는 Item 단위로 단건으로 처리하게 됩니다.
- 위와 같은 이유로 Processor 에서 주간/월간 Score 계산 시, Item 단위로 모두 Read 쿼리를 발생시키게 됩니다.
- **Read 쿼리 개수가 계산하는 상품 개수만큼 선형적으로 증가하게 될거 같은데, 순차적으로 실행되고, PK 를 기반으로 검색하기 때문에 관계가 없을까요? 아니면 Batch 단위로 동작하도록 수정해야 할까요?**


## ✅ Checklist
- [X]  Spring Batch Job 을 작성하고, 파라미터 기반으로 동작시킬 수 있다.
- [X]  Chunk Oriented Processing (Reader/Processor/Writer or Tasklet) 기반의 배치 처리를 구현했다.
- [X]  집계 결과를 저장할 Materialized View 의 구조를 설계하고 올바르게 적재했다.

### 🧩 Ranking API
- [X]  API 가 일간, 주간, 월간 랭킹을 제공하며 조회해야 하는 형태에 따라 적절한 데이터를 기반으로 랭킹을 제공한다.
